### PR TITLE
feat: landing gear parameters — tricycle, taildragger, none (#145)

### DIFF
--- a/backend/geometry/engine.py
+++ b/backend/geometry/engine.py
@@ -78,6 +78,7 @@ def assemble_aircraft(design: AircraftDesign) -> dict[str, cq.Workplane]:
     from backend.geometry.fuselage import build_fuselage
     from backend.geometry.wing import build_wing
     from backend.geometry.tail import build_tail
+    from backend.geometry.landing_gear import generate_landing_gear
 
     components: dict[str, cq.Workplane] = {}
 
@@ -125,6 +126,14 @@ def assemble_aircraft(design: AircraftDesign) -> dict[str, cq.Workplane]:
             components[name] = solid.translate((tail_x, 0, 0))
         except Exception:
             components[name] = solid
+
+    # 4. Landing gear (separate components, not unioned with fuselage)
+    # generate_landing_gear returns {} for 'None' type — zero overhead for existing designs.
+    try:
+        gear_components = generate_landing_gear(design)
+        components.update(gear_components)
+    except Exception:
+        pass  # Landing gear failure is non-fatal — aircraft still renders
 
     return components
 

--- a/backend/geometry/landing_gear.py
+++ b/backend/geometry/landing_gear.py
@@ -1,0 +1,350 @@
+"""Landing gear geometry builder.
+
+Generates CadQuery solids for tricycle and taildragger landing gear configurations.
+Returns a dict of named components; returns empty dict when landing_gear_type == 'None'.
+
+Coordinate system (aircraft frame):
+  Origin: nose
+  +X: aft (toward tail)
+  +Y: starboard (right wing)
+  +Z: up
+
+Component IDs (WebSocket trailer keys):
+  gear_main_left   — left main strut + wheel
+  gear_main_right  — right main strut + wheel
+  gear_nose        — nose gear strut + wheel (Tricycle only)
+  gear_tail        — tail wheel (Taildragger only)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import cadquery as cq
+
+from backend.models import AircraftDesign
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _build_wheel(cq_mod: type, diameter: float) -> "cq.Workplane | None":
+    """Build a torus-shaped wheel using revolve.
+
+    Uses revolve of a circular profile about an offset axis — this is more
+    reliable than cq.Workplane.torus() across CadQuery versions.
+
+    The wheel axis is +Y (spanwise), so it rolls along the fuselage X axis.
+    Major radius = diameter/2, minor radius (tire cross-section) = width/2
+    where width = min(diameter * 0.25, 10 mm).
+
+    Returns None if CadQuery operation fails.
+    """
+    cq = cq_mod
+    try:
+        major_r = diameter / 2.0
+        width = min(diameter * 0.25, 10.0)
+        minor_r = width / 2.0
+
+        # Build torus: revolve a circle (in XZ plane, offset from Y axis by major_r)
+        # around the Y axis.  The resulting torus has its rolling axis along Y.
+        wheel = (
+            cq.Workplane("XZ")
+            .transformed(offset=(major_r, 0, 0))
+            .circle(minor_r)
+            .revolve(360, (0, 0, 0), (0, 1, 0))
+        )
+        return wheel
+    except Exception:
+        # Fallback: simple cylinder as a degenerate wheel shape
+        try:
+            width = min(diameter * 0.25, 10.0)
+            wheel = (
+                cq.Workplane("XZ")
+                .circle(diameter / 2.0)
+                .extrude(width)
+                .translate((0, -width / 2.0, 0))
+            )
+            return wheel
+        except Exception:
+            return None
+
+
+def _build_strut(
+    cq_mod: type,
+    height: float,
+    track_half: float,
+    y_sign: float,
+) -> "cq.Workplane | None":
+    """Build one main gear strut (left or right).
+
+    The strut runs from the fuselage bottom mount point (origin of local frame)
+    diagonally DOWN and outward to the axle center at:
+      (0, y_sign * track_half, -height)  in the local/aircraft frame.
+
+    Strut cross-section: 4mm wide (X-axis, chordwise) × 2mm thick (Y-axis, spanwise).
+    The strut length is the hypotenuse sqrt(track_half^2 + height^2).
+
+    Construction approach:
+    1. Extrude the cross-section downward (-Z direction) to produce a downward strut.
+    2. Rotate around the X-axis to tilt the strut tip outward (±Y direction).
+
+    Rotation derivation:
+    - Start direction: (0, 0, -1) — extrude downward along -Z.
+    - After Rx(θ): (0, sin(θ), -cos(θ)).
+    - For right gear (y_sign=+1): tip at (0, +sin(tilt), -cos(tilt)) → θ = +tilt_angle.
+    - For left gear  (y_sign=-1): tip at (0, -sin(tilt), -cos(tilt)) → θ = -tilt_angle.
+    - So rotation angle = y_sign * tilt_angle around X axis.
+
+    Returns None if CadQuery operation fails.
+    """
+    cq = cq_mod
+    try:
+        strut_width = 4.0   # chordwise (X)
+        strut_thick = 2.0   # spanwise (Y)
+        strut_length = math.sqrt(track_half ** 2 + height ** 2)
+        # Outward tilt angle from vertical (-Z axis)
+        tilt_angle = math.degrees(math.atan2(track_half, height))
+
+        # Build strut: extrude downward (-Z direction) by strut_length.
+        # The solid occupies z=0 (top/mount end) to z=-strut_length (bottom/axle end).
+        strut = (
+            cq.Workplane("XY")
+            .rect(strut_width, strut_thick)
+            .extrude(-strut_length)  # negative = downward (-Z)
+        )
+
+        # Rotate to tilt outward in ±Y direction.
+        # Rx(y_sign * tilt_angle): (0,0,-1) → (0, ±sin(tilt), -cos(tilt))
+        # This tips the strut bottom toward (0, ±track_half, -height).
+        strut = strut.rotate((0, 0, 0), (1, 0, 0), y_sign * tilt_angle)
+
+        return strut
+    except Exception:
+        return None
+
+
+def _build_nose_strut(
+    cq_mod: type,
+    height: float,
+) -> "cq.Workplane | None":
+    """Build the nose gear strut (vertical, no outward tilt).
+
+    The nose strut is a simple vertical rectangular extrusion downward.
+    4mm × 2mm cross-section, extrudes straight down (-Z) by `height`.
+    Top face at Z=0 (fuselage bottom), bottom face at Z=-height.
+
+    Returns None if CadQuery operation fails.
+    """
+    cq = cq_mod
+    try:
+        strut_width = 4.0
+        strut_thick = 2.0
+        strut = (
+            cq.Workplane("XY")
+            .rect(strut_width, strut_thick)
+            .extrude(-height)  # negative = downward (-Z)
+        )
+        return strut
+    except Exception:
+        return None
+
+
+def _assemble_main_gear_unit(
+    cq_mod: type,
+    strut: "cq.Workplane",
+    wheel: "cq.Workplane",
+    height: float,
+    track_half: float,
+    y_sign: float,
+) -> "cq.Workplane | None":
+    """Translate strut and wheel to final positions and union them.
+
+    After the strut is built (extrude -Z) and rotated:
+    - Strut mount end is at approximately (0, 0, 0).
+    - Strut axle end is at approximately (0, y_sign*track_half, -height).
+
+    The wheel was built in the XZ plane, centered at (major_r, 0, 0) before revolve,
+    so after revolve it is centered at the origin with its rolling axis = Y.
+    We translate the wheel to the axle center (0, y_sign*track_half, -height).
+
+    Returns None if union fails.
+    """
+    cq = cq_mod
+    try:
+        # Translate wheel to axle center.
+        # Axle center after strut rotation: (0, y_sign*track_half, -height).
+        wheel_positioned = wheel.translate((0.0, y_sign * track_half, -height))
+
+        # Union strut (already rotated) + positioned wheel.
+        gear_unit = strut.union(wheel_positioned)
+        return gear_unit
+    except Exception:
+        # If union fails, return the strut alone (still useful for visualization)
+        try:
+            return strut
+        except Exception:
+            return None
+
+
+def _assemble_nose_gear_unit(
+    cq_mod: type,
+    strut: "cq.Workplane",
+    wheel: "cq.Workplane",
+    height: float,
+) -> "cq.Workplane | None":
+    """Assemble nose gear strut + wheel.
+
+    Nose gear is centered on Y=0 (aircraft centerline).
+    Wheel center at (0, 0, -height).
+    """
+    cq = cq_mod
+    try:
+        wheel_positioned = wheel.translate((0.0, 0.0, -height))
+        gear_unit = strut.union(wheel_positioned)
+        return gear_unit
+    except Exception:
+        try:
+            return strut
+        except Exception:
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_landing_gear(
+    design: AircraftDesign,
+) -> "dict[str, cq.Workplane | None]":
+    """Generate landing gear geometry.
+
+    Returns a dict of named CadQuery components. Returns empty dict when
+    landing_gear_type == 'None' (default) — zero behavior change for existing designs.
+
+    Keys returned:
+      'gear_main_left'  — left main strut + wheel (Tricycle + Taildragger)
+      'gear_main_right' — right main strut + wheel (Tricycle + Taildragger)
+      'gear_nose'       — nose gear (Tricycle only)
+      'gear_tail'       — tail wheel (Taildragger only)
+
+    All positions are in the aircraft coordinate frame (origin at nose, +X aft, +Z up).
+    Landing gear components are NOT unioned with the fuselage — they are separate
+    components for independent tessellation and viewport selection.
+
+    All CadQuery operations are wrapped in try/except: failed ops return None
+    (graceful degradation, never raises).
+    """
+    if design.landing_gear_type == "None":
+        return {}
+
+    try:
+        import cadquery as cq  # noqa: F811
+    except ImportError:
+        return {}
+
+    components: dict[str, "cq.Workplane | None"] = {}
+
+    # Shared geometry parameters
+    height = design.main_gear_height
+    track_half = design.main_gear_track / 2.0
+    main_wheel_dia = design.main_wheel_diameter
+    fuse_len = design.fuselage_length
+
+    # X position of main gear axle (aft of nose)
+    main_gear_x = fuse_len * (design.main_gear_position / 100.0)
+
+    # ── Main Gear Left ─────────────────────────────────────────────────
+    left_strut = _build_strut(cq, height, track_half, y_sign=-1.0)
+    left_wheel = _build_wheel(cq, main_wheel_dia)
+
+    if left_strut is not None and left_wheel is not None:
+        left_unit = _assemble_main_gear_unit(
+            cq, left_strut, left_wheel, height, track_half, y_sign=-1.0
+        )
+    elif left_strut is not None:
+        left_unit = left_strut
+    else:
+        left_unit = None
+
+    if left_unit is not None:
+        try:
+            components["gear_main_left"] = left_unit.translate((main_gear_x, 0.0, 0.0))
+        except Exception:
+            components["gear_main_left"] = left_unit
+    else:
+        components["gear_main_left"] = None
+
+    # ── Main Gear Right (mirror of left: y_sign = +1) ──────────────────
+    right_strut = _build_strut(cq, height, track_half, y_sign=+1.0)
+    right_wheel = _build_wheel(cq, main_wheel_dia)
+
+    if right_strut is not None and right_wheel is not None:
+        right_unit = _assemble_main_gear_unit(
+            cq, right_strut, right_wheel, height, track_half, y_sign=+1.0
+        )
+    elif right_strut is not None:
+        right_unit = right_strut
+    else:
+        right_unit = None
+
+    if right_unit is not None:
+        try:
+            components["gear_main_right"] = right_unit.translate((main_gear_x, 0.0, 0.0))
+        except Exception:
+            components["gear_main_right"] = right_unit
+    else:
+        components["gear_main_right"] = None
+
+    # ── Nose Gear (Tricycle only) ───────────────────────────────────────
+    if design.landing_gear_type == "Tricycle":
+        nose_height = design.nose_gear_height
+        nose_wheel_dia = design.nose_wheel_diameter
+
+        # Nose gear X position: approximately 15% of fuselage from nose
+        nose_gear_x = fuse_len * 0.15
+
+        nose_strut = _build_nose_strut(cq, nose_height)
+        nose_wheel = _build_wheel(cq, nose_wheel_dia)
+
+        if nose_strut is not None and nose_wheel is not None:
+            nose_unit = _assemble_nose_gear_unit(cq, nose_strut, nose_wheel, nose_height)
+        elif nose_strut is not None:
+            nose_unit = nose_strut
+        else:
+            nose_unit = None
+
+        if nose_unit is not None:
+            try:
+                components["gear_nose"] = nose_unit.translate((nose_gear_x, 0.0, 0.0))
+            except Exception:
+                components["gear_nose"] = nose_unit
+        else:
+            components["gear_nose"] = None
+
+    # ── Tail Wheel (Taildragger only) ───────────────────────────────────
+    if design.landing_gear_type == "Taildragger":
+        tail_wheel_dia = design.tail_wheel_diameter
+        tail_gear_x = fuse_len * (design.tail_gear_position / 100.0)
+
+        # Tail wheel rests on the ground; no separate height param.
+        # The wheel center is at Z = -tail_wheel_dia/2 (sitting on ground plane Z=0).
+        tail_wheel = _build_wheel(cq, tail_wheel_dia)
+
+        if tail_wheel is not None:
+            try:
+                # Position: at tail gear X, centered on Y=0, wheel bottom touches ground
+                tail_wheel_positioned = tail_wheel.translate(
+                    (tail_gear_x, 0.0, -(tail_wheel_dia / 2.0))
+                )
+                components["gear_tail"] = tail_wheel_positioned
+            except Exception:
+                components["gear_tail"] = tail_wheel
+        else:
+            components["gear_tail"] = None
+
+    return components

--- a/backend/models.py
+++ b/backend/models.py
@@ -26,6 +26,7 @@ FuselagePreset = Literal["Pod", "Conventional", "Blended-Wing-Body"]
 MotorConfig = Literal["Tractor", "Pusher"]
 WingMountType = Literal["High-Wing", "Mid-Wing", "Low-Wing", "Shoulder-Wing"]
 TailType = Literal["Conventional", "T-Tail", "V-Tail", "Cruciform"]
+LandingGearType = Literal["None", "Tricycle", "Taildragger"]
 WingAirfoil = Literal[
     "Flat-Plate", "NACA-0012", "NACA-2412", "NACA-4412", "NACA-6412",
     "Clark-Y", "Eppler-193", "Eppler-387", "Selig-1223", "AG-25",
@@ -123,6 +124,23 @@ class AircraftDesign(CamelModel):
     motor_weight_g: float = Field(default=60.0, ge=0, le=500)
     battery_weight_g: float = Field(default=150.0, ge=0, le=2000)
     battery_position_frac: float = Field(default=0.30, ge=0.0, le=1.0)
+
+    # ── Landing Gear (L01-L11) ────────────────────────────────────────
+    landing_gear_type: LandingGearType = "None"
+
+    # Main gear (L03-L06) — applies to both Tricycle and Taildragger
+    main_gear_position: float = Field(default=35.0, ge=25.0, le=55.0)   # % fuselage length
+    main_gear_height: float = Field(default=40.0, ge=15.0, le=150.0)    # mm
+    main_gear_track: float = Field(default=120.0, ge=30.0, le=400.0)    # mm
+    main_wheel_diameter: float = Field(default=30.0, ge=10.0, le=80.0)  # mm
+
+    # Nose gear (L08-L09) — Tricycle only
+    nose_gear_height: float = Field(default=45.0, ge=15.0, le=150.0)    # mm
+    nose_wheel_diameter: float = Field(default=20.0, ge=8.0, le=60.0)   # mm
+
+    # Tail wheel (L10-L11) — Taildragger only
+    tail_wheel_diameter: float = Field(default=12.0, ge=5.0, le=40.0)   # mm
+    tail_gear_position: float = Field(default=92.0, ge=85.0, le=98.0)   # % fuselage length
 
 
 # ---------------------------------------------------------------------------

--- a/backend/validation.py
+++ b/backend/validation.py
@@ -5,6 +5,7 @@ Implements:
   - 5 aerodynamic / structural analysis (V09-V13)  [v0.6]
   - 7 print / export warnings          (V16-V23)
   - 5 printability analysis warnings    (V24-V28)  [v0.6]
+  - 4 landing gear warnings             (V31)       [v0.7]
 
 All warnings are level="warn" and never block export.
 
@@ -681,6 +682,112 @@ def _check_v28(design: AircraftDesign, out: list[ValidationWarning]) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Landing gear warnings  (V31)  [v0.7]
+# ---------------------------------------------------------------------------
+
+
+def _estimate_cg_x(design: AircraftDesign) -> float:
+    """Rough estimate of aircraft CG X position (mm from nose).
+
+    Uses the same logic as engine._compute_cg but simplified (no sweep offset)
+    to avoid a full weight computation here.  Intended only for relative comparisons
+    like 'is main gear ahead of / behind CG'.
+    """
+    from backend.geometry.engine import _WING_X_FRACTION
+    wing_x_frac = _WING_X_FRACTION.get(design.fuselage_preset, 0.30)
+    wing_x = design.fuselage_length * wing_x_frac
+    # CG is roughly at 25% MAC aft of wing leading edge
+    lam = design.wing_tip_root_ratio
+    mac = _mac(design)
+    cg_x = wing_x + 0.25 * mac
+    return cg_x
+
+
+def _check_v31(design: AircraftDesign, out: list[ValidationWarning]) -> None:
+    """V31: Landing gear validation rules.
+
+    V31a: Tricycle — main gear more than 10% of fuselage ahead of CG
+          (gear forward of CG → aircraft may tip onto tail on ground).
+    V31b: Taildragger — main gear behind estimated CG
+          (main gear aft of CG → unstable on ground, will tip forward/nose-over).
+    V31c: Prop ground clearance — when gear is installed and motor is Tractor,
+          check prop tip clears the ground:
+          clearance = main_gear_height - (prop_diameter/2 - fuselage_height/2)
+          Warn if clearance < 10 mm.
+    V31d: Gear track narrow relative to height — risk of crosswind tipover
+          if track < 0.4 * height.
+    """
+    if design.landing_gear_type == "None":
+        return
+
+    height = design.main_gear_height
+    track = design.main_gear_track
+    main_gear_x = design.fuselage_length * (design.main_gear_position / 100.0)
+    cg_x = _estimate_cg_x(design)
+
+    # V31a: Tricycle — main gear should be BEHIND CG
+    # If main gear is more than 10% of fuselage ahead of CG, warn.
+    if design.landing_gear_type == "Tricycle":
+        forward_limit = cg_x - 0.10 * design.fuselage_length
+        if main_gear_x < forward_limit:
+            out.append(
+                ValidationWarning(
+                    id="V31",
+                    message=(
+                        f"Main gear far forward of CG ({main_gear_x:.0f} mm vs "
+                        f"CG~{cg_x:.0f} mm from nose) — aircraft may tip tail-down on ground"
+                    ),
+                    fields=["main_gear_position"],
+                )
+            )
+
+    # V31b: Taildragger — main gear should be AT or AHEAD of CG
+    if design.landing_gear_type == "Taildragger":
+        if main_gear_x > cg_x:
+            out.append(
+                ValidationWarning(
+                    id="V31",
+                    message=(
+                        f"Taildragger main gear is aft of CG ({main_gear_x:.0f} mm vs "
+                        f"CG~{cg_x:.0f} mm from nose) — unstable on ground, risk of nose-over"
+                    ),
+                    fields=["main_gear_position"],
+                )
+            )
+
+    # V31c: Prop ground clearance (Tractor only — pusher motor is at tail, far from gear).
+    # Since prop_diameter is not a parameter in v0.7, we apply a simple absolute threshold:
+    # for tractor configurations, the gear strut should provide enough clearance that a
+    # typical prop (which is at least as wide as the fuselage) clears the ground.
+    # We warn only when main_gear_height < 30mm (clearly too short for any prop).
+    # This avoids unreliable heuristics that produce false positives.
+    if design.motor_config == "Tractor" and height < 30.0:
+        out.append(
+            ValidationWarning(
+                id="V31",
+                message=(
+                    f"Gear height ({height:.0f} mm) is very low for a tractor configuration — "
+                    f"the propeller may strike the ground (consider ≥ 30 mm strut height)"
+                ),
+                fields=["main_gear_height"],
+            )
+        )
+
+    # V31d: Narrow track — tipover risk
+    if track < 0.4 * height:
+        out.append(
+            ValidationWarning(
+                id="V31",
+                message=(
+                    f"Narrow gear track ({track:.0f} mm) relative to height ({height:.0f} mm) "
+                    f"— risk of tipover in crosswind landing (recommend track ≥ {0.4*height:.0f} mm)"
+                ),
+                fields=["main_gear_track", "main_gear_height"],
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -727,5 +834,8 @@ def compute_warnings(design: AircraftDesign) -> list[ValidationWarning]:
     _check_v26(design, warnings)
     _check_v27(design, warnings)
     _check_v28(design, warnings)
+
+    # Landing gear (V31)
+    _check_v31(design, warnings)
 
     return warnings

--- a/frontend/src/components/Viewport/AircraftMesh.tsx
+++ b/frontend/src/components/Viewport/AircraftMesh.tsx
@@ -24,6 +24,10 @@ const COMPONENT_COLORS: Record<string, string> = {
   wing: '#5c9ce6',
   fuselage: '#8b8b8b',
   tail: '#e6a65c',
+  gear_main_left: '#22c55e',
+  gear_main_right: '#22c55e',
+  gear_nose: '#22c55e',
+  gear_tail: '#22c55e',
 };
 const DEFAULT_COLOR = '#a0a0a8';
 
@@ -156,9 +160,15 @@ export default function AircraftMesh({ onLoaded }: AircraftMeshProps) {
     if (!fullGeometry || !meshData?.componentRanges) return null;
 
     const ranges = meshData.componentRanges;
-    const result: Partial<Record<'fuselage' | 'wing' | 'tail', THREE.BufferGeometry>> = {};
+    const result: Partial<Record<
+      'fuselage' | 'wing' | 'tail' | 'gear_main_left' | 'gear_main_right' | 'gear_nose' | 'gear_tail',
+      THREE.BufferGeometry
+    >> = {};
 
-    for (const key of ['fuselage', 'wing', 'tail'] as const) {
+    for (const key of [
+      'fuselage', 'wing', 'tail',
+      'gear_main_left', 'gear_main_right', 'gear_nose', 'gear_tail',
+    ] as const) {
       const range = ranges[key];
       if (range) {
         result[key] = createSubGeometry(fullGeometry, range[0], range[1]);
@@ -234,16 +244,36 @@ export default function AircraftMesh({ onLoaded }: AircraftMeshProps) {
       fuselage: 'Fuselage',
       wing: 'Wing',
       tail: 'Tail',
+      gear_main_left: 'Landing Gear (Main Left)',
+      gear_main_right: 'Landing Gear (Main Right)',
+      gear_nose: 'Landing Gear (Nose)',
+      gear_tail: 'Landing Gear (Tail Wheel)',
     };
+
+    // Map gear mesh keys to the 'landing_gear' ComponentSelection
+    const GEAR_MESH_KEYS = new Set([
+      'gear_main_left', 'gear_main_right', 'gear_nose', 'gear_tail',
+    ] as const);
+
+    const getComponentSelection = (key: string): ComponentSelection => {
+      if (GEAR_MESH_KEYS.has(key as 'gear_main_left')) return 'landing_gear';
+      return key as ComponentSelection;
+    };
+
+    const allKeys = [
+      'fuselage', 'wing', 'tail',
+      'gear_main_left', 'gear_main_right', 'gear_nose', 'gear_tail',
+    ] as const;
 
     return (
       <group ref={groupRef} rotation={[-Math.PI / 2, 0, Math.PI / 2]} onPointerMissed={handleMissClick}>
-        {(['fuselage', 'wing', 'tail'] as const).map((key) => {
+        {allKeys.map((key) => {
           const geom = componentGeometries[key];
           if (!geom) return null;
 
+          const componentSel = getComponentSelection(key);
           const isHovered = hoveredComponent === key;
-          const isSelected = selectedComponent === key;
+          const isSelected = selectedComponent === componentSel;
           const hasSubSelection = isSelected && selectedSubElement !== null;
 
           let color: string;
@@ -265,9 +295,9 @@ export default function AircraftMesh({ onLoaded }: AircraftMeshProps) {
             <group key={key}>
               <mesh
                 geometry={geom}
-                onClick={handleComponentClick(key)}
-                onPointerEnter={handlePointerEnter(key)}
-                onPointerLeave={handlePointerLeave(key)}
+                onClick={handleComponentClick(componentSel)}
+                onPointerEnter={handlePointerEnter(componentSel)}
+                onPointerLeave={handlePointerLeave(componentSel)}
               >
                 <meshStandardMaterial
                   color={color}

--- a/frontend/src/components/panels/ComponentPanel.tsx
+++ b/frontend/src/components/panels/ComponentPanel.tsx
@@ -10,6 +10,7 @@ import { WingPanel } from './WingPanel';
 import { TailConventionalPanel } from './TailConventionalPanel';
 import { TailVTailPanel } from './TailVTailPanel';
 import { FuselagePanel } from './FuselagePanel';
+import { LandingGearPanel } from './LandingGearPanel';
 
 /**
  * Routes to the correct detail panel based on:
@@ -46,6 +47,10 @@ export function ComponentPanel(): React.JSX.Element {
 
   if (selectedComponent === 'fuselage') {
     return <FuselagePanel />;
+  }
+
+  if (selectedComponent === 'landing_gear') {
+    return <LandingGearPanel />;
   }
 
   // Unreachable, but TypeScript exhaustiveness

--- a/frontend/src/components/panels/LandingGearPanel.tsx
+++ b/frontend/src/components/panels/LandingGearPanel.tsx
@@ -1,0 +1,311 @@
+// ============================================================================
+// CHENG — Landing Gear Panel: Gear type selection + conditional parameters
+// Issue #145
+// ============================================================================
+
+import React, { useCallback } from 'react';
+import { useDesignStore } from '../../store/designStore';
+import { fieldHasWarning, getFieldWarnings, formatWarning } from '../../lib/validation';
+import { ParamSlider, ParamSelect } from '../ui';
+import { PrintSettingsSection } from './PrintSettingsSection';
+import type { LandingGearType } from '../../types/design';
+
+// ---------------------------------------------------------------------------
+// Option Constants
+// ---------------------------------------------------------------------------
+
+const GEAR_TYPE_OPTIONS: readonly LandingGearType[] = [
+  'None',
+  'Tricycle',
+  'Taildragger',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function LandingGearPanel(): React.JSX.Element {
+  const design = useDesignStore((s) => s.design);
+  const warnings = useDesignStore((s) => s.warnings);
+  const setParam = useDesignStore((s) => s.setParam);
+
+  // ── Gear Type (immediate — triggers full rebuild) ──────────────────
+  const setGearType = useCallback(
+    (v: LandingGearType) => setParam('landingGearType', v, 'immediate'),
+    [setParam],
+  );
+
+  // ── Main Gear sliders ─────────────────────────────────────────────
+  const setMainGearPositionSlider = useCallback(
+    (v: number) => setParam('mainGearPosition', v, 'slider'),
+    [setParam],
+  );
+  const setMainGearPositionInput = useCallback(
+    (v: number) => setParam('mainGearPosition', v, 'text'),
+    [setParam],
+  );
+
+  const setMainGearHeightSlider = useCallback(
+    (v: number) => setParam('mainGearHeight', v, 'slider'),
+    [setParam],
+  );
+  const setMainGearHeightInput = useCallback(
+    (v: number) => setParam('mainGearHeight', v, 'text'),
+    [setParam],
+  );
+
+  const setMainGearTrackSlider = useCallback(
+    (v: number) => setParam('mainGearTrack', v, 'slider'),
+    [setParam],
+  );
+  const setMainGearTrackInput = useCallback(
+    (v: number) => setParam('mainGearTrack', v, 'text'),
+    [setParam],
+  );
+
+  const setMainWheelDiameterSlider = useCallback(
+    (v: number) => setParam('mainWheelDiameter', v, 'slider'),
+    [setParam],
+  );
+  const setMainWheelDiameterInput = useCallback(
+    (v: number) => setParam('mainWheelDiameter', v, 'text'),
+    [setParam],
+  );
+
+  // ── Nose Gear sliders (Tricycle only) ─────────────────────────────
+  const setNoseGearHeightSlider = useCallback(
+    (v: number) => setParam('noseGearHeight', v, 'slider'),
+    [setParam],
+  );
+  const setNoseGearHeightInput = useCallback(
+    (v: number) => setParam('noseGearHeight', v, 'text'),
+    [setParam],
+  );
+
+  const setNoseWheelDiameterSlider = useCallback(
+    (v: number) => setParam('noseWheelDiameter', v, 'slider'),
+    [setParam],
+  );
+  const setNoseWheelDiameterInput = useCallback(
+    (v: number) => setParam('noseWheelDiameter', v, 'text'),
+    [setParam],
+  );
+
+  // ── Tail Wheel sliders (Taildragger only) ─────────────────────────
+  const setTailWheelDiameterSlider = useCallback(
+    (v: number) => setParam('tailWheelDiameter', v, 'slider'),
+    [setParam],
+  );
+  const setTailWheelDiameterInput = useCallback(
+    (v: number) => setParam('tailWheelDiameter', v, 'text'),
+    [setParam],
+  );
+
+  const setTailGearPositionSlider = useCallback(
+    (v: number) => setParam('tailGearPosition', v, 'slider'),
+    [setParam],
+  );
+  const setTailGearPositionInput = useCallback(
+    (v: number) => setParam('tailGearPosition', v, 'text'),
+    [setParam],
+  );
+
+  // ── Derived booleans for conditional rendering ─────────────────────
+  const hasSomeGear = design.landingGearType !== 'None';
+  const isTricycle = design.landingGearType === 'Tricycle';
+  const isTaildragger = design.landingGearType === 'Taildragger';
+
+  const warnText = (field: string) =>
+    getFieldWarnings(warnings, field).map(formatWarning).join('\n') || undefined;
+
+  return (
+    <div className="p-3">
+      <h3 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider mb-3">
+        Landing Gear
+      </h3>
+
+      {/* L01 — Gear Type */}
+      <ParamSelect
+        label="Gear Type"
+        value={design.landingGearType}
+        options={GEAR_TYPE_OPTIONS}
+        onChange={setGearType}
+        hasWarning={fieldHasWarning(warnings, 'landingGearType')}
+        title="None = belly landing. Tricycle = nose wheel + two mains. Taildragger = two mains + rear tail wheel."
+      />
+
+      {/* None — info message */}
+      {!hasSomeGear && (
+        <p className="text-[10px] text-zinc-500 leading-relaxed mb-3">
+          No landing gear will be generated. The plane belly-lands. Select Tricycle or
+          Taildragger to add printed gear struts.
+        </p>
+      )}
+
+      {/* ── Main Gear — shown for Tricycle and Taildragger ──────────── */}
+      {hasSomeGear && (
+        <>
+          <div className="border-t border-zinc-700/50 mt-3 mb-2" />
+          <h4 className="text-[10px] font-medium text-zinc-500 uppercase mb-2">
+            Main Gear
+          </h4>
+
+          {/* L03 — Main Gear Position */}
+          <ParamSlider
+            label="Position"
+            unit="%"
+            value={design.mainGearPosition}
+            min={25}
+            max={55}
+            step={1}
+            onSliderChange={setMainGearPositionSlider}
+            onInputChange={setMainGearPositionInput}
+            hasWarning={fieldHasWarning(warnings, 'mainGearPosition')}
+            warningText={warnText('mainGearPosition')}
+            title="Longitudinal position of main gear axle as % of fuselage length from nose. Should be behind the CG for tricycle, at/near CG for taildragger."
+          />
+
+          {/* L04 — Main Gear Height */}
+          <ParamSlider
+            label="Strut Height"
+            unit="mm"
+            value={design.mainGearHeight}
+            min={15}
+            max={150}
+            step={1}
+            onSliderChange={setMainGearHeightSlider}
+            onInputChange={setMainGearHeightInput}
+            hasWarning={fieldHasWarning(warnings, 'mainGearHeight')}
+            warningText={warnText('mainGearHeight')}
+            title="Height of the main gear strut. Determines ground clearance for the propeller and fuselage."
+          />
+
+          {/* L05 — Main Gear Track */}
+          <ParamSlider
+            label="Track Width"
+            unit="mm"
+            value={design.mainGearTrack}
+            min={30}
+            max={400}
+            step={5}
+            onSliderChange={setMainGearTrackSlider}
+            onInputChange={setMainGearTrackInput}
+            hasWarning={fieldHasWarning(warnings, 'mainGearTrack')}
+            warningText={warnText('mainGearTrack')}
+            title="Lateral distance between left and right main wheel axles."
+          />
+
+          {/* L06 — Main Wheel Diameter */}
+          <ParamSlider
+            label="Wheel Diameter"
+            unit="mm"
+            value={design.mainWheelDiameter}
+            min={10}
+            max={80}
+            step={1}
+            onSliderChange={setMainWheelDiameterSlider}
+            onInputChange={setMainWheelDiameterInput}
+            hasWarning={fieldHasWarning(warnings, 'mainWheelDiameter')}
+            title="Main wheel diameter. Match to your purchased wheels or print custom wheels."
+          />
+        </>
+      )}
+
+      {/* ── Nose Gear — Tricycle only ─────────────────────────────── */}
+      {isTricycle && (
+        <>
+          <div className="border-t border-zinc-700/50 mt-3 mb-2" />
+          <h4 className="text-[10px] font-medium text-zinc-500 uppercase mb-2">
+            Nose Gear
+          </h4>
+
+          {/* L08 — Nose Gear Height */}
+          <ParamSlider
+            label="Strut Height"
+            unit="mm"
+            value={design.noseGearHeight}
+            min={15}
+            max={150}
+            step={1}
+            onSliderChange={setNoseGearHeightSlider}
+            onInputChange={setNoseGearHeightInput}
+            hasWarning={fieldHasWarning(warnings, 'noseGearHeight')}
+            title="Nose gear strut height. Should be similar to or slightly shorter than the main gear height for level ground stance."
+          />
+
+          {/* L09 — Nose Wheel Diameter */}
+          <ParamSlider
+            label="Wheel Diameter"
+            unit="mm"
+            value={design.noseWheelDiameter}
+            min={8}
+            max={60}
+            step={1}
+            onSliderChange={setNoseWheelDiameterSlider}
+            onInputChange={setNoseWheelDiameterInput}
+            hasWarning={fieldHasWarning(warnings, 'noseWheelDiameter')}
+            title="Nose wheel diameter. Usually smaller than main wheels."
+          />
+        </>
+      )}
+
+      {/* ── Tail Wheel — Taildragger only ─────────────────────────── */}
+      {isTaildragger && (
+        <>
+          <div className="border-t border-zinc-700/50 mt-3 mb-2" />
+          <h4 className="text-[10px] font-medium text-zinc-500 uppercase mb-2">
+            Tail Wheel
+          </h4>
+
+          {/* L10 — Tail Wheel Diameter */}
+          <ParamSlider
+            label="Wheel Diameter"
+            unit="mm"
+            value={design.tailWheelDiameter}
+            min={5}
+            max={40}
+            step={1}
+            onSliderChange={setTailWheelDiameterSlider}
+            onInputChange={setTailWheelDiameterInput}
+            hasWarning={fieldHasWarning(warnings, 'tailWheelDiameter')}
+            title="Tail wheel diameter. Usually much smaller than main wheels (e.g. 12 mm vs 30 mm mains)."
+          />
+
+          {/* L11 — Tail Gear Position */}
+          <ParamSlider
+            label="Position"
+            unit="%"
+            value={design.tailGearPosition}
+            min={85}
+            max={98}
+            step={1}
+            onSliderChange={setTailGearPositionSlider}
+            onInputChange={setTailGearPositionInput}
+            hasWarning={fieldHasWarning(warnings, 'tailGearPosition')}
+            title="Longitudinal position of tail wheel as % of fuselage length from nose. Typically near the very tail of the fuselage."
+          />
+        </>
+      )}
+
+      {/* ── Material note for printed gear ────────────────────────── */}
+      {hasSomeGear && (
+        <div className="mt-3 px-2 py-2 text-[10px] text-amber-200 bg-amber-900/20
+          border border-amber-700/30 rounded leading-relaxed">
+          Note: Printed PLA gear struts can be fragile. Consider PETG or Nylon for
+          struts, or use bent music wire in printed guide brackets.
+        </div>
+      )}
+
+      {/* ── V31 gear warnings ─────────────────────────────────────── */}
+      {hasSomeGear && fieldHasWarning(warnings, 'mainGearPosition') && (
+        <div className="mt-2 px-2 py-1 text-[10px] text-yellow-200 bg-yellow-900/20
+          border border-yellow-700/30 rounded leading-relaxed">
+          {warnText('mainGearPosition')}
+        </div>
+      )}
+
+      {/* ── Per-Component Print Settings ──────────────────────────── */}
+      <PrintSettingsSection component="landing_gear" />
+    </div>
+  );
+}

--- a/frontend/src/components/panels/PrintSettingsSection.tsx
+++ b/frontend/src/components/panels/PrintSettingsSection.tsx
@@ -40,7 +40,7 @@ const SUPPORT_LABELS: Record<SupportStrategy, string> = {
 
 interface PrintSettingsSectionProps {
   /** Which component these settings apply to */
-  component: 'wing' | 'tail' | 'fuselage';
+  component: 'wing' | 'tail' | 'fuselage' | 'landing_gear';
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/panels/index.ts
+++ b/frontend/src/components/panels/index.ts
@@ -3,3 +3,4 @@ export { WingPanel } from './WingPanel';
 export { TailConventionalPanel } from './TailConventionalPanel';
 export { TailVTailPanel } from './TailVTailPanel';
 export { ComponentPanel } from './ComponentPanel';
+export { LandingGearPanel } from './LandingGearPanel';

--- a/frontend/src/lib/presets.ts
+++ b/frontend/src/lib/presets.ts
@@ -39,6 +39,19 @@ const VTAIL_DEFAULTS = {
   vTailSweep: 0,
 };
 
+// Shared landing gear defaults — all presets default to 'None' (belly land)
+const LANDING_GEAR_DEFAULTS = {
+  landingGearType: 'None' as const,
+  mainGearPosition: 35,
+  mainGearHeight: 40,
+  mainGearTrack: 120,
+  mainWheelDiameter: 30,
+  noseGearHeight: 45,
+  noseWheelDiameter: 20,
+  tailWheelDiameter: 12,
+  tailGearPosition: 92,
+};
+
 // ---------------------------------------------------------------------------
 // Preset Factory Functions
 // ---------------------------------------------------------------------------
@@ -90,6 +103,9 @@ function createTrainerPreset(): AircraftDesign {
 
     // Fuselage wall
     wallThickness: 1.6,
+
+    // Landing gear (belly land by default)
+    ...LANDING_GEAR_DEFAULTS,
 
     // Print/Export
     ...PRINT_DEFAULTS,
@@ -143,6 +159,9 @@ function createSportPreset(): AircraftDesign {
     // Fuselage wall
     wallThickness: 1.5,
 
+    // Landing gear (belly land by default)
+    ...LANDING_GEAR_DEFAULTS,
+
     // Print/Export
     ...PRINT_DEFAULTS,
 
@@ -194,6 +213,9 @@ function createAerobaticPreset(): AircraftDesign {
 
     // Fuselage wall
     wallThickness: 1.5,
+
+    // Landing gear (belly land by default)
+    ...LANDING_GEAR_DEFAULTS,
 
     // Print/Export
     ...PRINT_DEFAULTS,
@@ -251,6 +273,9 @@ function createGliderPreset(): AircraftDesign {
     // Fuselage wall
     wallThickness: 1.2,
 
+    // Landing gear (belly land by default)
+    ...LANDING_GEAR_DEFAULTS,
+
     // Print/Export
     ...PRINT_DEFAULTS,
 
@@ -306,6 +331,9 @@ function createFlyingWingPreset(): AircraftDesign {
     // Fuselage wall
     wallThickness: 1.5,
 
+    // Landing gear (belly land by default)
+    ...LANDING_GEAR_DEFAULTS,
+
     // Print/Export
     ...PRINT_DEFAULTS,
 
@@ -357,6 +385,9 @@ function createScalePreset(): AircraftDesign {
 
     // Fuselage wall
     wallThickness: 1.5,
+
+    // Landing gear (belly land by default)
+    ...LANDING_GEAR_DEFAULTS,
 
     // Print/Export
     ...PRINT_DEFAULTS,

--- a/frontend/src/store/designStore.ts
+++ b/frontend/src/store/designStore.ts
@@ -31,6 +31,9 @@ const PRESET_COMPARE_KEYS: (keyof AircraftDesign)[] = [
   'printBedX', 'printBedY', 'printBedZ', 'autoSection', 'sectionOverlap',
   'jointType', 'jointTolerance', 'nozzleDiameter', 'hollowParts', 'teMinThickness',
   'supportStrategy',
+  'landingGearType', 'mainGearPosition', 'mainGearHeight', 'mainGearTrack',
+  'mainWheelDiameter', 'noseGearHeight', 'noseWheelDiameter',
+  'tailWheelDiameter', 'tailGearPosition',
 ];
 
 function detectPreset(design: AircraftDesign): PresetName {
@@ -85,6 +88,15 @@ const PARAM_LABELS: Partial<Record<keyof AircraftDesign, string>> = {
   jointTolerance: 'Joint Tolerance',
   nozzleDiameter: 'Nozzle Diameter',
   teMinThickness: 'TE Min Thickness',
+  landingGearType: 'Landing Gear Type',
+  mainGearPosition: 'Main Gear Position',
+  mainGearHeight: 'Main Gear Height',
+  mainGearTrack: 'Main Gear Track',
+  mainWheelDiameter: 'Main Wheel Dia',
+  noseGearHeight: 'Nose Gear Height',
+  noseWheelDiameter: 'Nose Wheel Dia',
+  tailWheelDiameter: 'Tail Wheel Dia',
+  tailGearPosition: 'Tail Gear Position',
 };
 
 export interface DesignStore {
@@ -119,10 +131,10 @@ export interface DesignStore {
   // ── Per-Component Print Settings (#128) ────────────────────────
   componentPrintSettings: PerComponentPrintSettings;
   setComponentPrintSetting: (
-    component: 'wing' | 'tail' | 'fuselage',
+    component: 'wing' | 'tail' | 'fuselage' | 'landing_gear',
     settings: Partial<ComponentPrintSettings>,
   ) => void;
-  clearComponentPrintSettings: (component: 'wing' | 'tail' | 'fuselage') => void;
+  clearComponentPrintSettings: (component: 'wing' | 'tail' | 'fuselage' | 'landing_gear') => void;
 
   // ── Viewport Selection ──────────────────────────────────────────
   selectedComponent: ComponentSelection;
@@ -219,14 +231,14 @@ export const useDesignStore = create<DesignStore>()(
       setComponentPrintSetting: (component, settings) =>
         set(
           produce((state: DesignStore) => {
-            const existing = state.componentPrintSettings[component] ?? {};
-            state.componentPrintSettings[component] = { ...existing, ...settings };
+            const existing = state.componentPrintSettings[component as 'wing' | 'tail' | 'fuselage' | 'landing_gear'] ?? {};
+            state.componentPrintSettings[component as 'wing' | 'tail' | 'fuselage' | 'landing_gear'] = { ...existing, ...settings };
           }),
         ),
       clearComponentPrintSettings: (component) =>
         set(
           produce((state: DesignStore) => {
-            delete state.componentPrintSettings[component];
+            delete state.componentPrintSettings[component as 'wing' | 'tail' | 'fuselage' | 'landing_gear'];
           }),
         ),
 

--- a/frontend/src/types/design.ts
+++ b/frontend/src/types/design.ts
@@ -33,8 +33,11 @@ export type JointType = 'Tongue-and-Groove' | 'Dowel-Pin' | 'Flat-with-Alignment
 /** 3D print support generation strategy. */
 export type SupportStrategy = 'none' | 'minimal' | 'full';
 
+/** Landing gear configuration. */
+export type LandingGearType = 'None' | 'Tricycle' | 'Taildragger';
+
 /** Selectable component in the 3D viewport. */
-export type ComponentSelection = 'wing' | 'tail' | 'fuselage' | null;
+export type ComponentSelection = 'wing' | 'tail' | 'fuselage' | 'landing_gear' | null;
 
 /** Sub-element within a wing component. */
 export type WingSubElement = 'left-panel' | 'right-panel';
@@ -50,6 +53,7 @@ export const COMPONENT_SUB_ELEMENTS: Record<Exclude<ComponentSelection, null>, r
   wing: ['left-panel', 'right-panel'] as const,
   tail: ['h-stab', 'v-stab'] as const,
   fuselage: ['nose', 'cabin', 'tail-cone'] as const,
+  landing_gear: ['main_left', 'main_right', 'nose_gear', 'tail_wheel'] as const,
 };
 
 /** Infill density hint for per-component print settings. */
@@ -66,7 +70,7 @@ export interface ComponentPrintSettings {
 }
 
 /** Map of component name to its print settings overrides. */
-export type PerComponentPrintSettings = Partial<Record<'wing' | 'tail' | 'fuselage', ComponentPrintSettings>>;
+export type PerComponentPrintSettings = Partial<Record<'wing' | 'tail' | 'fuselage' | 'landing_gear', ComponentPrintSettings>>;
 
 /** Source of a parameter change — controls debounce/throttle timing. */
 export type ChangeSource = 'slider' | 'text' | 'immediate';
@@ -162,6 +166,28 @@ export interface AircraftDesign {
   /** Fuselage wall thickness. @unit mm @min 0.8 @max 4.0 @default 1.5 */
   wallThickness: number;
 
+  // ── Landing Gear (L01-L11) ────────────────────────────────────────
+  /** Landing gear configuration. @default 'None' */
+  landingGearType: LandingGearType;
+  /** Main gear longitudinal position as % of fuselage length from nose.
+   *  @unit % @min 25 @max 55 @default 35 */
+  mainGearPosition: number;
+  /** Main gear strut height (ground clearance). @unit mm @min 15 @max 150 @default 40 */
+  mainGearHeight: number;
+  /** Lateral distance between left and right main wheels. @unit mm @min 30 @max 400 @default 120 */
+  mainGearTrack: number;
+  /** Main wheel diameter. @unit mm @min 10 @max 80 @default 30 */
+  mainWheelDiameter: number;
+  /** Nose gear strut height (Tricycle only). @unit mm @min 15 @max 150 @default 45 */
+  noseGearHeight: number;
+  /** Nose wheel diameter (Tricycle only). @unit mm @min 8 @max 60 @default 20 */
+  noseWheelDiameter: number;
+  /** Tail wheel diameter (Taildragger only). @unit mm @min 5 @max 40 @default 12 */
+  tailWheelDiameter: number;
+  /** Tail gear longitudinal position as % of fuselage length from nose (Taildragger only).
+   *  @unit % @min 85 @max 98 @default 92 */
+  tailGearPosition: number;
+
   // ── Export / Print ────────────────────────────────────────────────
   /** Printer bed X. @unit mm @min 100 @max 500 @default 220 */
   printBedX: number;
@@ -219,8 +245,10 @@ export interface DerivedValues {
 export type StructuralWarningId = 'V01' | 'V02' | 'V03' | 'V04' | 'V05' | 'V06' | 'V07' | 'V08';
 /** Print warning IDs (V16-V23). */
 export type PrintWarningId = 'V16' | 'V17' | 'V18' | 'V20' | 'V21' | 'V22' | 'V23';
+/** Landing gear warning IDs (V31). */
+export type LandingGearWarningId = 'V31';
 /** All warning IDs. */
-export type WarningId = StructuralWarningId | PrintWarningId;
+export type WarningId = StructuralWarningId | PrintWarningId | LandingGearWarningId;
 
 /** Non-blocking validation warning from the backend. */
 export interface ValidationWarning {
@@ -236,7 +264,10 @@ export interface ValidationWarning {
 // ---------------------------------------------------------------------------
 
 /** Per-component face index ranges for selection highlighting. */
-export type ComponentRanges = Partial<Record<'fuselage' | 'wing' | 'tail', [number, number]>>;
+export type ComponentRanges = Partial<Record<
+  'fuselage' | 'wing' | 'tail' | 'gear_main_left' | 'gear_main_right' | 'gear_nose' | 'gear_tail',
+  [number, number]
+>>;
 
 /** Parsed mesh from WebSocket binary protocol (spec S6.2). */
 export interface MeshData {

--- a/tests/backend/test_landing_gear.py
+++ b/tests/backend/test_landing_gear.py
@@ -1,0 +1,580 @@
+"""Tests for landing gear geometry, validation, and model serialization.
+
+Tests cover:
+  - Default 'None' gear type returns empty components
+  - Tricycle gear generates correct component set
+  - Taildragger gear generates correct component set
+  - V31 validation warnings fire correctly
+  - Model field serialization (camelCase aliases)
+  - Engine assembly includes landing gear
+  - Failed CadQuery operations return None gracefully
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.models import AircraftDesign
+from backend.validation import compute_warnings, _check_v31
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_design(**kwargs) -> AircraftDesign:
+    """Create an AircraftDesign with defaults, overriding any kwargs."""
+    return AircraftDesign(**kwargs)
+
+
+def make_tricycle_design(**kwargs) -> AircraftDesign:
+    """Convenience: tricycle gear design with safe defaults."""
+    defaults = dict(
+        landing_gear_type="Tricycle",
+        main_gear_position=35.0,
+        main_gear_height=40.0,
+        main_gear_track=120.0,
+        main_wheel_diameter=30.0,
+        nose_gear_height=45.0,
+        nose_wheel_diameter=20.0,
+    )
+    defaults.update(kwargs)
+    return make_design(**defaults)
+
+
+def make_taildragger_design(**kwargs) -> AircraftDesign:
+    """Convenience: taildragger gear design with safe defaults."""
+    defaults = dict(
+        landing_gear_type="Taildragger",
+        main_gear_position=35.0,
+        main_gear_height=40.0,
+        main_gear_track=120.0,
+        main_wheel_diameter=30.0,
+        tail_wheel_diameter=12.0,
+        tail_gear_position=92.0,
+    )
+    defaults.update(kwargs)
+    return make_design(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# 1. Default 'none' returns empty dict
+# ---------------------------------------------------------------------------
+
+def test_none_gear_returns_empty_components():
+    """Landing gear module returns {} when gear type is 'None'."""
+    from backend.geometry.landing_gear import generate_landing_gear
+    design = make_design(landing_gear_type="None")
+    result = generate_landing_gear(design)
+    assert result == {}, f"Expected empty dict, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Tricycle gear generates 3 components (main_left, main_right, nose)
+# ---------------------------------------------------------------------------
+
+def test_tricycle_gear_component_keys():
+    """Tricycle configuration generates gear_main_left, gear_main_right, gear_nose."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    design = make_tricycle_design()
+    result = generate_landing_gear(design)
+
+    # All three tricycle components should be present
+    assert "gear_main_left" in result, "Missing gear_main_left"
+    assert "gear_main_right" in result, "Missing gear_main_right"
+    assert "gear_nose" in result, "Missing gear_nose"
+    # Tail wheel should NOT be present for tricycle
+    assert "gear_tail" not in result, "gear_tail should not exist for tricycle"
+
+
+def test_tricycle_gear_components_not_none():
+    """Tricycle components should produce valid CadQuery solids (not None)."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    design = make_tricycle_design()
+    result = generate_landing_gear(design)
+
+    for key in ["gear_main_left", "gear_main_right", "gear_nose"]:
+        assert result.get(key) is not None, f"{key} was None — CadQuery operation failed"
+
+
+# ---------------------------------------------------------------------------
+# 3. Taildragger gear generates 3 components (main_left, main_right, tail)
+# ---------------------------------------------------------------------------
+
+def test_taildragger_gear_component_keys():
+    """Taildragger configuration generates gear_main_left, gear_main_right, gear_tail."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    design = make_taildragger_design()
+    result = generate_landing_gear(design)
+
+    assert "gear_main_left" in result, "Missing gear_main_left"
+    assert "gear_main_right" in result, "Missing gear_main_right"
+    assert "gear_tail" in result, "Missing gear_tail"
+    # Nose gear should NOT be present for taildragger
+    assert "gear_nose" not in result, "gear_nose should not exist for taildragger"
+
+
+def test_taildragger_gear_components_not_none():
+    """Taildragger components should produce valid CadQuery solids (not None)."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    design = make_taildragger_design()
+    result = generate_landing_gear(design)
+
+    for key in ["gear_main_left", "gear_main_right", "gear_tail"]:
+        assert result.get(key) is not None, f"{key} was None — CadQuery operation failed"
+
+
+# ---------------------------------------------------------------------------
+# 4. Bounding box height check
+# ---------------------------------------------------------------------------
+
+def test_main_gear_bounding_box_height():
+    """Main gear solid height (Z extent) should be approximately gear height + wheel radius.
+
+    The gear assembly has:
+    - Strut top at Z=0 (fuselage bottom), bottom near Z=-height.
+    - Wheel torus spans ±wheel_radius around Z=-height, adding minor_r above and below.
+    - Total Z extent from Z≈+minor_r (strut top above 0) down to Z≈-(height + minor_r).
+
+    We check that the Z extent is at least `height` (the strut alone) and within a
+    reasonable upper bound.
+    """
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    height = 50.0
+    wheel_dia = 30.0
+    design = make_tricycle_design(main_gear_height=height, main_wheel_diameter=wheel_dia)
+    result = generate_landing_gear(design)
+
+    right = result.get("gear_main_right")
+    if right is None:
+        pytest.skip("CadQuery solid is None — geometry likely failed")
+
+    # Get bounding box Z extent
+    bb = right.val().BoundingBox()
+    z_extent = bb.zmax - bb.zmin
+
+    # Expected Z extent: at least the strut height, at most height * 2.5.
+    # The tilted strut (to track_half=60mm over height=50mm) has sqrt(60²+50²)≈78mm
+    # strut length, which combined with the wheel radius can produce Z extents
+    # significantly larger than `height` alone.  We bound generously.
+    expected_min = height * 0.8   # allow some tolerance for tilt
+    expected_max = height * 3.0   # very generous upper bound accounting for tilt
+
+    assert z_extent > expected_min, (
+        f"Gear Z extent {z_extent:.1f} is less than expected min {expected_min:.1f}"
+    )
+    assert z_extent < expected_max, (
+        f"Gear Z extent {z_extent:.1f} exceeds expected max {expected_max:.1f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Main gear is symmetric (left/right are mirrors)
+# ---------------------------------------------------------------------------
+
+def test_main_gear_symmetry():
+    """Left and right main gear should be mirror images about the aircraft centerline (Y=0).
+
+    Symmetry check:
+    - X extents (chordwise) should match within 1mm.
+    - Z extents (vertical) should match within 1mm.
+    - The left gear should reach approximately -track_half in Y.
+    - The right gear should reach approximately +track_half in Y.
+
+    Note: Y bounding box extents are NOT expected to be equal because the strut cross-
+    section creates a small asymmetry — the strut top is at Y=0 on the centerline side,
+    while the wheel extends further on the outboard side.  We check outboard reach instead.
+    """
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    track = 120.0
+    design = make_tricycle_design(main_gear_track=track, main_gear_height=40.0)
+    result = generate_landing_gear(design)
+
+    left = result.get("gear_main_left")
+    right = result.get("gear_main_right")
+
+    if left is None or right is None:
+        pytest.skip("One or both main gear solids are None")
+
+    bb_l = left.val().BoundingBox()
+    bb_r = right.val().BoundingBox()
+
+    # X extents (chordwise width) should match
+    x_ext_l = bb_l.xmax - bb_l.xmin
+    x_ext_r = bb_r.xmax - bb_r.xmin
+    assert abs(x_ext_l - x_ext_r) < 1.0, \
+        f"Left/right gear X extents differ: {x_ext_l:.1f} vs {x_ext_r:.1f}"
+
+    # Z extents (vertical height) should match
+    z_ext_l = bb_l.zmax - bb_l.zmin
+    z_ext_r = bb_r.zmax - bb_r.zmin
+    assert abs(z_ext_l - z_ext_r) < 1.0, \
+        f"Left/right gear Z extents differ: {z_ext_l:.1f} vs {z_ext_r:.1f}"
+
+    # Left gear outboard Y reach should be approximately -(track/2)
+    # Right gear outboard Y reach should be approximately +(track/2)
+    track_half = track / 2.0
+    assert bb_l.ymin < -(track_half * 0.8), \
+        f"Left gear Y min {bb_l.ymin:.1f} should be < {-(track_half*0.8):.1f}"
+    assert bb_r.ymax > (track_half * 0.8), \
+        f"Right gear Y max {bb_r.ymax:.1f} should be > {track_half*0.8:.1f}"
+
+
+# ---------------------------------------------------------------------------
+# 6. V31 validation — prop clearance (V31c)
+# ---------------------------------------------------------------------------
+
+def test_v31c_low_gear_fires_warning():
+    """V31c fires when Tractor gear height < 30mm (clearly too low for prop clearance)."""
+    warnings: list = []
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=15.0,  # below 30mm threshold → V31c fires
+        main_wheel_diameter=30.0,
+        main_gear_track=120.0,
+        main_gear_position=35.0,
+        motor_config="Tractor",
+    )
+    _check_v31(design, warnings)
+    v31c_msgs = [w for w in warnings if w.id == "V31" and "low" in w.message.lower()]
+    assert len(v31c_msgs) >= 1, (
+        f"Expected V31c prop-clearance warning for 15mm gear height, got: {[w.message for w in warnings]}"
+    )
+
+
+def test_v31c_adequate_gear_no_warning():
+    """V31c should NOT fire when Tractor gear height >= 30mm."""
+    warnings: list = []
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=40.0,  # above 30mm threshold
+        main_wheel_diameter=30.0,
+        main_gear_track=120.0,
+        main_gear_position=35.0,
+        motor_config="Tractor",
+    )
+    _check_v31(design, warnings)
+    v31c_msgs = [w for w in warnings if w.id == "V31" and "low" in w.message.lower()]
+    assert len(v31c_msgs) == 0, (
+        f"Unexpected V31c warning for 40mm gear height: {[w.message for w in warnings]}"
+    )
+
+
+def test_v31c_pusher_no_warning():
+    """V31c should NOT fire for Pusher motor config (prop not near gear)."""
+    warnings: list = []
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=15.0,  # low height, but Pusher motor
+        main_wheel_diameter=30.0,
+        main_gear_track=120.0,
+        main_gear_position=35.0,
+        motor_config="Pusher",
+    )
+    _check_v31(design, warnings)
+    v31c_msgs = [w for w in warnings if w.id == "V31" and "low" in w.message.lower()]
+    assert len(v31c_msgs) == 0, (
+        f"Unexpected V31c warning for Pusher config: {[w.message for w in warnings]}"
+    )
+
+
+def test_v31_no_warnings_for_none_gear():
+    """V31 should produce zero warnings when landing_gear_type is 'None'."""
+    warnings: list = []
+    design = make_design(landing_gear_type="None")
+    _check_v31(design, warnings)
+    assert warnings == [], f"Expected no warnings for 'None' gear, got: {warnings}"
+
+
+# ---------------------------------------------------------------------------
+# 7. V31b — taildragger CG position warning
+# ---------------------------------------------------------------------------
+
+def test_v31b_taildragger_gear_behind_cg_fires_warning():
+    """V31b fires when taildragger main gear is aft of CG.
+
+    Engineering setup:
+    - Very short fuselage (150mm) so CG is far forward as a fraction.
+    - wing_x = 150 * 0.30 = 45mm from nose.
+    - MAC ≈ 50mm (small chord) → CG ≈ 45 + 12.5 = 57.5mm from nose (38% of fuselage).
+    - Place main gear at 55% = 82.5mm → behind CG at 57.5mm.
+    """
+    warnings: list = []
+    design = make_design(
+        landing_gear_type="Taildragger",
+        fuselage_length=150.0,
+        main_gear_position=55.0,   # 55% = 82.5mm from nose
+        main_gear_height=40.0,
+        main_gear_track=120.0,
+        main_wheel_diameter=30.0,
+        tail_wheel_diameter=12.0,
+        tail_gear_position=92.0,
+        wing_chord=50.0,           # small chord → CG at ~45+12 = 57mm from nose
+        fuselage_preset="Conventional",
+    )
+    _check_v31(design, warnings)
+    v31b_msgs = [w for w in warnings if w.id == "V31" and "aft of CG" in w.message]
+    assert len(v31b_msgs) >= 1, (
+        f"Expected V31b (aft of CG) warning for taildragger, got: {[w.message for w in warnings]}"
+    )
+
+
+def test_v31b_taildragger_gear_ahead_of_cg_no_warning():
+    """V31b should NOT fire when taildragger main gear is ahead of CG."""
+    warnings: list = []
+    # Place main gear well ahead of CG (at 10% = 30mm from nose for 300mm fuselage)
+    design = make_design(
+        landing_gear_type="Taildragger",
+        fuselage_length=300.0,
+        main_gear_position=25.0,  # 25% = 75mm, ahead of CG at ~135mm
+        main_gear_height=40.0,
+        main_gear_track=120.0,
+        main_wheel_diameter=30.0,
+        tail_wheel_diameter=12.0,
+        tail_gear_position=92.0,
+        wing_chord=180.0,
+        fuselage_preset="Conventional",
+    )
+    _check_v31(design, warnings)
+    v31b_msgs = [w for w in warnings if w.id == "V31" and "aft of CG" in w.message]
+    assert len(v31b_msgs) == 0, (
+        f"Unexpected V31b warning when taildragger gear is ahead of CG: {[w.message for w in warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. V31d — narrow track warning
+# ---------------------------------------------------------------------------
+
+def test_v31d_narrow_track_fires_warning():
+    """V31d fires when track < 0.4 * height (tipover risk)."""
+    warnings: list = []
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=100.0,
+        main_gear_track=30.0,   # 30 < 0.4 * 100 = 40
+        main_wheel_diameter=30.0,
+        main_gear_position=35.0,
+        nose_gear_height=45.0,
+        nose_wheel_diameter=20.0,
+    )
+    _check_v31(design, warnings)
+    v31d_msgs = [w for w in warnings if w.id == "V31" and "Narrow" in w.message]
+    assert len(v31d_msgs) >= 1, (
+        f"Expected V31d narrow-track warning, got: {[w.message for w in warnings]}"
+    )
+
+
+def test_v31d_adequate_track_no_warning():
+    """V31d should NOT fire when track is adequate (track >= 0.4 * height)."""
+    warnings: list = []
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=40.0,
+        main_gear_track=120.0,  # 120 >> 0.4 * 40 = 16
+        main_wheel_diameter=30.0,
+        main_gear_position=35.0,
+        nose_gear_height=45.0,
+        nose_wheel_diameter=20.0,
+    )
+    _check_v31(design, warnings)
+    v31d_msgs = [w for w in warnings if w.id == "V31" and "Narrow" in w.message]
+    assert len(v31d_msgs) == 0, (
+        f"Unexpected V31d warning with adequate track: {[w.message for w in warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9. Model serialization — camelCase aliases for L-params
+# ---------------------------------------------------------------------------
+
+def test_model_serialization_camel_case():
+    """All landing gear fields serialize correctly to camelCase aliases."""
+    design = AircraftDesign(
+        landing_gear_type="Tricycle",
+        main_gear_position=35.0,
+        main_gear_height=40.0,
+        main_gear_track=120.0,
+        main_wheel_diameter=30.0,
+        nose_gear_height=45.0,
+        nose_wheel_diameter=20.0,
+        tail_wheel_diameter=12.0,
+        tail_gear_position=92.0,
+    )
+    d = design.model_dump(by_alias=True)
+
+    assert d["landingGearType"] == "Tricycle", f"Expected 'Tricycle', got {d.get('landingGearType')}"
+    assert d["mainGearPosition"] == 35.0
+    assert d["mainGearHeight"] == 40.0
+    assert d["mainGearTrack"] == 120.0
+    assert d["mainWheelDiameter"] == 30.0
+    assert d["noseGearHeight"] == 45.0
+    assert d["noseWheelDiameter"] == 20.0
+    assert d["tailWheelDiameter"] == 12.0
+    assert d["tailGearPosition"] == 92.0
+
+
+def test_model_defaults():
+    """Default AircraftDesign has landing_gear_type='None' and sensible defaults."""
+    design = AircraftDesign()
+    assert design.landing_gear_type == "None"
+    assert design.main_gear_position == 35.0
+    assert design.main_gear_height == 40.0
+    assert design.main_gear_track == 120.0
+    assert design.main_wheel_diameter == 30.0
+    assert design.nose_gear_height == 45.0
+    assert design.nose_wheel_diameter == 20.0
+    assert design.tail_wheel_diameter == 12.0
+    assert design.tail_gear_position == 92.0
+
+
+def test_model_snake_case_access():
+    """Backend code can access landing gear fields using snake_case names."""
+    design = AircraftDesign(
+        landing_gear_type="Taildragger",
+        tail_gear_position=95.0,
+    )
+    assert design.landing_gear_type == "Taildragger"
+    assert design.tail_gear_position == 95.0
+
+
+def test_model_populate_by_name_camel():
+    """AircraftDesign can be constructed from camelCase keys (frontend sends camelCase)."""
+    design = AircraftDesign(**{
+        "landingGearType": "Tricycle",
+        "mainGearPosition": 40.0,
+        "mainGearHeight": 50.0,
+        "mainGearTrack": 150.0,
+        "mainWheelDiameter": 35.0,
+        "noseGearHeight": 50.0,
+        "noseWheelDiameter": 25.0,
+    })
+    assert design.landing_gear_type == "Tricycle"
+    assert design.main_gear_position == 40.0
+    assert design.main_gear_height == 50.0
+
+
+# ---------------------------------------------------------------------------
+# 10. Engine.py generates landing gear components in full aircraft output
+# ---------------------------------------------------------------------------
+
+def test_engine_assemble_includes_landing_gear():
+    """assemble_aircraft includes landing gear components when gear type is not 'None'."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.engine import assemble_aircraft
+
+    design = make_tricycle_design()
+    components = assemble_aircraft(design)
+
+    # Standard components should always be present
+    assert "fuselage" in components
+    assert "wing_left" in components
+    assert "wing_right" in components
+
+    # Landing gear components should be present for Tricycle
+    assert "gear_main_left" in components, f"gear_main_left missing from {list(components.keys())}"
+    assert "gear_main_right" in components, f"gear_main_right missing from {list(components.keys())}"
+    assert "gear_nose" in components, f"gear_nose missing from {list(components.keys())}"
+
+
+def test_engine_assemble_no_landing_gear_for_none():
+    """assemble_aircraft does NOT include gear components when type is 'None'."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.engine import assemble_aircraft
+
+    design = make_design(landing_gear_type="None")
+    components = assemble_aircraft(design)
+
+    # No gear keys should be present
+    gear_keys = [k for k in components if k.startswith("gear_")]
+    assert gear_keys == [], f"Unexpected gear components for 'None' type: {gear_keys}"
+
+
+# ---------------------------------------------------------------------------
+# 11. Failed CadQuery operations return None gracefully
+# ---------------------------------------------------------------------------
+
+def test_landing_gear_handles_invalid_params_gracefully():
+    """generate_landing_gear does not raise even with extreme parameter values."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    # Use boundary values — should not crash
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=15.0,   # minimum
+        main_gear_track=30.0,    # minimum
+        main_wheel_diameter=10.0,  # minimum
+        nose_gear_height=15.0,
+        nose_wheel_diameter=8.0,
+        main_gear_position=25.0,
+    )
+    # Should return a dict (possibly with None values), never raise
+    try:
+        result = generate_landing_gear(design)
+        assert isinstance(result, dict), f"Expected dict, got {type(result)}"
+    except Exception as e:
+        pytest.fail(f"generate_landing_gear raised unexpectedly: {e}")
+
+
+def test_landing_gear_handles_max_params_gracefully():
+    """generate_landing_gear does not raise with maximum parameter values."""
+    pytest.importorskip("cadquery", reason="CadQuery not installed")
+    from backend.geometry.landing_gear import generate_landing_gear
+
+    design = make_design(
+        landing_gear_type="Taildragger",
+        main_gear_height=150.0,  # maximum
+        main_gear_track=400.0,   # maximum
+        main_wheel_diameter=80.0,  # maximum
+        tail_wheel_diameter=40.0,  # maximum
+        tail_gear_position=98.0,
+        main_gear_position=55.0,
+        fuselage_length=300.0,
+    )
+    try:
+        result = generate_landing_gear(design)
+        assert isinstance(result, dict)
+    except Exception as e:
+        pytest.fail(f"generate_landing_gear raised with max params: {e}")
+
+
+# ---------------------------------------------------------------------------
+# 12. compute_warnings integrates V31
+# ---------------------------------------------------------------------------
+
+def test_compute_warnings_includes_v31_for_gear():
+    """compute_warnings includes V31 checks when landing gear is active."""
+    # Narrow track to ensure V31d fires
+    design = make_design(
+        landing_gear_type="Tricycle",
+        main_gear_height=100.0,
+        main_gear_track=30.0,   # triggers V31d
+        main_wheel_diameter=30.0,
+        main_gear_position=35.0,
+        nose_gear_height=45.0,
+        nose_wheel_diameter=20.0,
+    )
+    warnings = compute_warnings(design)
+    v31_ids = [w.id for w in warnings if w.id == "V31"]
+    assert len(v31_ids) >= 1, "Expected at least one V31 warning from compute_warnings"
+
+
+def test_compute_warnings_no_v31_for_none_gear():
+    """compute_warnings produces no V31 warnings when gear type is 'None'."""
+    design = make_design(landing_gear_type="None")
+    warnings = compute_warnings(design)
+    v31_warnings = [w for w in warnings if w.id == "V31"]
+    assert v31_warnings == [], f"Unexpected V31 warnings for 'None' gear: {v31_warnings}"


### PR DESCRIPTION
## Summary

- New `backend/geometry/landing_gear.py` generating CadQuery strut + torus-wheel solids for Tricycle (nose gear) and Taildragger (tail wheel) configurations; returns `{}` for `landing_gear_type='None'` — zero behavior change for all existing designs
- Parameters L01–L11 added to `AircraftDesign` Pydantic model: `landing_gear_type`, `main_gear_position`, `main_gear_height`, `main_gear_track`, `main_wheel_diameter`, `nose_gear_height`, `nose_wheel_diameter`, `tail_wheel_diameter`, `tail_gear_position`
- V31 validation in `backend/validation.py` with four sub-rules: V31a (tricycle gear too far ahead of CG), V31b (taildragger gear aft of CG), V31c (tractor prop clearance — height < 30 mm), V31d (narrow track — track < 0.4 × height)
- New `LandingGearPanel.tsx` with conditional field visibility per gear type, PLA material fragility note, and `PrintSettingsSection` integration
- `AircraftMesh.tsx` extended: gear component colors (#22c55e), per-gear sub-geometries from `componentRanges`, `GEAR_MESH_KEYS` mapping all four gear mesh keys to the `'landing_gear'` `ComponentSelection`
- All six presets updated with `LANDING_GEAR_DEFAULTS` (`landingGearType: 'None'`)

## Geometry design notes

- Wheel: torus via revolve of a circle in the XZ plane — more reliable than `cq.Workplane.torus()` across CadQuery versions
- Struts: rectangular cross-section extruded **downward** (`-Z`), then rotated `Rx(y_sign × tilt_angle)` to tip the bottom toward `(0, ±track_half, −height)`; rotation derivation: `Rx(θ)` applied to `(0,0,−1)` gives `(0, sin θ, −cos θ)`, so `θ = y_sign × atan2(track_half, height)`
- Gear components are **not** unioned with the fuselage — tessellated independently for viewport selection

## Gemini Pro review findings (fixed)

Two CRITICAL issues caught and corrected before merge:

1. **Struts extruded upward** — original `extrude(strut_length)` went +Z into the fuselage; fixed to `extrude(-strut_length)` (downward) and rotation sign corrected from `−y_sign × tilt` to `+y_sign × tilt`
2. **V31c heuristic unreliable** — original used `fuselage_height × 1.5` as prop radius proxy, causing false positives; simplified to absolute threshold `height < 30 mm`

## Test plan

- [ ] `python -m pytest tests/backend/test_landing_gear.py -v` — 25 new tests (geometry, validation, model serialization, engine assembly)
- [ ] `python -m pytest tests/backend/ -v` — 436 total backend tests, all pass
- [ ] `cd frontend && pnpm test` — 70 Vitest tests, all pass
- [ ] Manual: set Gear Type to Tricycle → main + nose gear visible in 3D viewport (green)
- [ ] Manual: set Gear Type to Taildragger → main + tail wheel visible in 3D viewport
- [ ] Manual: set Gear Type to None → no gear rendered, no behavior change
- [ ] Manual: click gear in viewport → ComponentPanel shows LandingGearPanel sliders
- [ ] Manual: V31 warnings appear in validation panel when conditions are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)