### PR TITLE
fix(geometry): fuselage sliders, tail positioning, V-tail sweep, pusher (#212, #216, #218, #219)

### DIFF
--- a/backend/geometry/tail.py
+++ b/backend/geometry/tail.py
@@ -289,16 +289,22 @@ def _build_v_tail_half(
     dihedral_rad = math.radians(dihedral)
     sweep_rad = math.radians(sweep_deg)
 
-    # Tip offset due to dihedral
+    # Tip offset due to dihedral (projected onto Y and Z world axes)
     tip_y = y_sign * half_span * math.cos(dihedral_rad)
     tip_z = half_span * math.sin(dihedral_rad)
 
-    # Sweep offset: tip LE moves aft along X
+    # #216: Sweep offset — tip chord centre moves aft in world X.
+    # tip_x = root_x + half_span * tan(sweep_rad).
+    # In the XZ workplane local frame: local-X = world-X, local-Y = world-Z,
+    # so transformed(offset=(sweep_offset_x, tip_z, 0)) after
+    # workplane(offset=tip_y) places the tip correctly in world space.
     sweep_offset_x = half_span * math.tan(sweep_rad)
 
-    # Loft from root to tip using chained workplane offsets
-    # workplane(offset=tip_y) moves along Y (XZ plane normal),
-    # transformed adds the Z offset from dihedral and X offset from sweep
+    # Loft from root to tip using chained workplane offsets.
+    # Incidence is applied via transformed(rotate=(0, 0, -incidence)) at the
+    # root workplane.  In the XZ plane, local Z = world -Y (spanwise axis),
+    # so rotating around local Z pitches the chord — this is the correct axis
+    # for incidence (commit 1856acb: fix yaw→pitch).
     result = (
         cq.Workplane("XZ")
         .transformed(rotate=(0, 0, -incidence))


### PR DESCRIPTION
## Summary

- **#212**: Tail position now auto-derives a minimum from `fuselage_length` in `engine.py`. New `_compute_tail_x()` helper enforces `tail_x >= 0.75 * fuselage_length`, so the tail moves aft as the fuselage grows. The user's `tail_arm` value is preserved when it's already large enough. CG calculator updated to use the same helper for consistency.
- **#216**: `v_tail_sweep` (T15) was already correctly wired via `sweep_offset_x = half_span * tan(sweep_rad)` applied in `transformed(offset=(...))`. Added explicit comments documenting the coordinate mapping so this is clear and verifiable.
- **#218**: Pusher motor boss was using `Workplane("YZ").transformed(offset=(length, 0, 0))` which shifted sideways in world Y (YZ plane local-X = world-Y), producing a stray circle in the 3D viewport. Fixed to `Workplane("YZ").workplane(offset=length)` which correctly shifts along the plane's normal (world X).
- **#219**: BWB fuselage `_build_bwb()` used hardcoded station fractions (0.2, 0.5, 0.8). Now uses `fuselage_nose_length`, `fuselage_cabin_length`, `fuselage_tail_length` via proportional scaling — same pattern as Conventional and Pod — so section length sliders update the BWB preview.

## Test plan

- [ ] All 581 backend tests pass (`python -m pytest tests/backend/ -v`)
- [ ] Fuselage length increase moves tail backwards in 3D preview
- [ ] V-tail sweep slider changes geometry visually
- [ ] Pusher motor no longer shows spurious circle in viewport
- [ ] Nose/cabin/tail cone sliders update BWB fuselage shape in preview
- [ ] Gemini Pro review: no CRITICAL/MAJOR issues (confirmed across 3 review rounds)

Closes #212, #216, #218, #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)