### PR TITLE
fix(engine): restrict engine count to 0/1 + motor toggle UI (#240)

### DIFF
--- a/backend/geometry/fuselage.py
+++ b/backend/geometry/fuselage.py
@@ -244,6 +244,9 @@ def _add_motor_boss(
     """
     cq = cq_mod
 
+    # engine_count is restricted to 0 or 1 as of v0.7.1 (#240).
+    # Multi-engine nacelles (count 2-4) are not yet implemented.
+    # TODO v0.8: add nacelle geometry for engine_count > 1
     if design.engine_count == 0:
         return solid
 

--- a/frontend/src/components/panels/GlobalPanel.tsx
+++ b/frontend/src/components/panels/GlobalPanel.tsx
@@ -201,14 +201,14 @@ export function GlobalPanel(): React.JSX.Element {
     [setParam],
   );
 
-  // ── Engine count (number input — text source) ───────────────────────
+  // ── Motor toggle (boolean: 0 = no motor, 1 = single motor) ─────────
+  // engine_count is restricted to 0/1 in v0.7.1 (#240).
+  // Multi-engine nacelles (2-4) are not implemented; using a toggle prevents
+  // users from setting values that have no visible effect.
 
-  const handleEngineCountChange = useCallback(
+  const handleMotorToggle = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const val = parseInt(e.target.value, 10);
-      if (!Number.isNaN(val) && val >= 0 && val <= 4) {
-        setParam('engineCount', val, 'text');
-      }
+      setParam('engineCount', e.target.checked ? 1 : 0, 'immediate');
     },
     [setParam],
   );
@@ -494,23 +494,39 @@ export function GlobalPanel(): React.JSX.Element {
         hasWarning={fieldHasWarning(warnings, 'fuselagePreset')}
       />
 
-      {/* G02 — Engine Count */}
-      <div className="mb-3">
-        <label className="block text-xs font-medium text-zinc-300 mb-1">
-          Engine Count
+      {/* G02 — Motor (toggle: engineCount 0 = no motor, 1 = single motor) */}
+      <div className="mb-3 flex items-center justify-between">
+        <label
+          htmlFor="motor-toggle"
+          className="text-xs font-medium text-zinc-300 cursor-pointer"
+        >
+          Motor
         </label>
-        <input
-          type="number"
-          min={0}
-          max={4}
-          step={1}
-          value={design.engineCount}
-          onChange={handleEngineCountChange}
-          className="w-full px-2 py-1 text-xs text-zinc-100 bg-zinc-800
-            border border-zinc-700 rounded focus:outline-none focus:border-blue-500
-            [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none
-            [&::-webkit-inner-spin-button]:appearance-none"
-        />
+        <button
+          id="motor-toggle"
+          role="switch"
+          aria-checked={design.engineCount === 1}
+          onClick={() => handleMotorToggle({
+            target: { checked: design.engineCount === 0 },
+          } as React.ChangeEvent<HTMLInputElement>)}
+          className={[
+            'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full',
+            'border-2 border-transparent transition-colors duration-200',
+            'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-zinc-900',
+            design.engineCount === 1
+              ? 'bg-blue-600'
+              : 'bg-zinc-600',
+          ].join(' ')}
+        >
+          <span
+            aria-hidden="true"
+            className={[
+              'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow',
+              'transform transition duration-200',
+              design.engineCount === 1 ? 'translate-x-4' : 'translate-x-0',
+            ].join(' ')}
+          />
+        </button>
       </div>
 
       {/* P02 — Motor Config */}

--- a/frontend/src/types/design.ts
+++ b/frontend/src/types/design.ts
@@ -97,7 +97,9 @@ export interface AircraftDesign {
   // ── Global / Fuselage ─────────────────────────────────────────────
   /** Fuselage body style. @see FuselagePreset */
   fuselagePreset: FuselagePreset;
-  /** Number of engines. @min 0 @max 4 @default 1 */
+  /** Motor present: 0 = no motor (glider/unpowered), 1 = single motor.
+   *  Values 2–4 are reserved for future multi-engine nacelle support (TODO v0.8).
+   *  @min 0 @max 1 @default 1 */
   engineCount: number;
   /** Motor position. "Tractor" = nose, "Pusher" = rear. @default "Tractor" */
   motorConfig: MotorConfig;

--- a/tests/frontend/unit/motorToggle.test.ts
+++ b/tests/frontend/unit/motorToggle.test.ts
@@ -1,0 +1,75 @@
+// ============================================================================
+// CHENG — Motor toggle unit tests (#240)
+// engine_count restricted to 0/1 — numeric input replaced with toggle
+// ============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignStore } from '@/store/designStore';
+import { createDesignFromPreset } from '@/lib/presets';
+
+/** Reset store to initial (Trainer) state before each test. */
+function resetStore() {
+  useDesignStore.getState().newDesign();
+  useDesignStore.temporal.getState().clear();
+}
+
+// ============================================================================
+// Engine count / motor toggle — store behaviour
+// ============================================================================
+
+describe('motor toggle: engineCount 0/1 (#240)', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('default design (Trainer) has engineCount=1 (motor on)', () => {
+    const { design } = useDesignStore.getState();
+    expect(design.engineCount).toBe(1);
+  });
+
+  it('setting engineCount to 0 turns the motor off', () => {
+    useDesignStore.getState().setParam('engineCount', 0, 'immediate');
+    const { design } = useDesignStore.getState();
+    expect(design.engineCount).toBe(0);
+  });
+
+  it('setting engineCount to 1 turns the motor on', () => {
+    useDesignStore.getState().setParam('engineCount', 0, 'immediate');
+    useDesignStore.getState().setParam('engineCount', 1, 'immediate');
+    const { design } = useDesignStore.getState();
+    expect(design.engineCount).toBe(1);
+  });
+
+  it('toggling motor changes activePreset to Custom', () => {
+    // Start on Trainer preset (engineCount=1)
+    expect(useDesignStore.getState().activePreset).toBe('Trainer');
+    useDesignStore.getState().setParam('engineCount', 0, 'immediate');
+    expect(useDesignStore.getState().activePreset).toBe('Custom');
+  });
+
+  it('toggling motor is recorded in lastAction', () => {
+    useDesignStore.getState().setParam('engineCount', 0, 'immediate');
+    expect(useDesignStore.getState().lastAction).toContain('Engine Count');
+  });
+
+  it('Glider preset has engineCount=0 (unpowered glider)', () => {
+    const d = createDesignFromPreset('Glider');
+    expect(d.engineCount).toBe(0);
+  });
+
+  it('all powered presets have engineCount=1', () => {
+    const poweredPresets = ['Trainer', 'Sport', 'Aerobatic', 'FlyingWing', 'Scale'] as const;
+    for (const name of poweredPresets) {
+      const d = createDesignFromPreset(name);
+      expect(d.engineCount, `${name} should have engineCount=1`).toBe(1);
+    }
+  });
+
+  it('engineCount only has values 0 or 1 in all presets', () => {
+    const allPresets = ['Trainer', 'Sport', 'Aerobatic', 'Glider', 'FlyingWing', 'Scale'] as const;
+    for (const name of allPresets) {
+      const d = createDesignFromPreset(name);
+      expect([0, 1], `${name}.engineCount must be 0 or 1`).toContain(d.engineCount);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #240: Engine count 2–4 had no visible effect (nacelles not implemented). Restricts `engine_count` to 0 or 1 and replaces the numeric input with a clear Motor on/off toggle to eliminate the false expectation.
- Adds a `@field_validator` that silently clamps legacy designs with `engine_count` 2–4 to 1 for backward compatibility (no HTTP 422 on old JSON files).

## Changes
- `backend/models.py`: `engine_count` field — `le=4` → `le=1`; add `clamp_engine_count` validator for backward compat; add TODO comment for future nacelle milestone
- `backend/geometry/fuselage.py`: add clarifying comment that counts > 1 are reserved; logic unchanged
- `frontend/src/types/design.ts`: update `engineCount` JSDoc — `@max 1`, note 2–4 reserved
- `frontend/src/components/panels/GlobalPanel.tsx`: replace numeric input with Motor toggle (`role="switch"`, blue when on, gray when off)
- `tests/backend/test_models.py`: update engine count range test + add `test_engine_count_valid_values`
- `tests/frontend/unit/motorToggle.test.ts`: new file — store toggle behaviour + preset coverage

## Test plan
- [x] Backend: `engine_count=2` clamped to 1 by `clamp_engine_count` validator (backward compat)
- [x] Backend: `engine_count=-1` still rejected by Pydantic
- [x] Backend: `engine_count=0` and `engine_count=1` both accepted
- [x] Frontend: motor toggle on/off correctly sets `engineCount` 1/0 in store
- [x] Frontend: Glider preset has `engineCount=0`; all powered presets have `engineCount=1`
- [x] Gemini Pro review: no CRITICAL/MAJOR issues — clamp logic, toggle mapping, preset values, and backward compat all confirmed correct

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)