### PR TITLE
fix(viewport): wing panel shading/alignment + per-panel selection (#241, #242)

### DIFF
--- a/frontend/src/store/designStore.ts
+++ b/frontend/src/store/designStore.ts
@@ -181,7 +181,12 @@ export interface DesignStore {
   // ── Viewport Selection ──────────────────────────────────────────
   selectedComponent: ComponentSelection;
   selectedSubElement: SubElementSelection;
+  /** Index of the currently selected wing panel (0-based), or null if none.
+   *  Applies to both left and right halves when wing_sections > 1 (#242). */
+  selectedPanel: number | null;
   setSelectedComponent: (component: ComponentSelection) => void;
+  /** Set the selected wing panel index. Null deselects. */
+  setSelectedPanel: (panelIndex: number | null) => void;
   /** Cycle to next sub-element within the currently selected component. */
   cycleSubElement: () => void;
 
@@ -380,8 +385,11 @@ export const useDesignStore = create<DesignStore>()(
       // ── Viewport ──────────────────────────────────────────────────
       selectedComponent: null,
       selectedSubElement: null,
+      selectedPanel: null,
       setSelectedComponent: (component) =>
-        set({ selectedComponent: component, selectedSubElement: null }),
+        set({ selectedComponent: component, selectedSubElement: null, selectedPanel: null }),
+      setSelectedPanel: (panelIndex) =>
+        set({ selectedPanel: panelIndex, selectedComponent: 'wing', selectedSubElement: null }),
       cycleSubElement: () => {
         const { selectedComponent, selectedSubElement } = get();
         if (!selectedComponent) return;
@@ -440,6 +448,7 @@ export const useDesignStore = create<DesignStore>()(
           meshData: null,
           selectedComponent: null,
           selectedSubElement: null,
+          selectedPanel: null,
         });
       },
 

--- a/frontend/src/types/design.ts
+++ b/frontend/src/types/design.ts
@@ -344,7 +344,9 @@ export interface ValidationWarning {
 
 /** Per-component face index ranges for selection highlighting.
  *  Includes control surfaces, multi-section wing panel sub-keys, and landing gear.
- *  wing_left/wing_right are separate halves for distinct shading (#228). */
+ *  wing_left/wing_right are separate halves for distinct shading (#228).
+ *  Per-panel sub-keys wing_left_0, wing_left_1, … wing_right_0, wing_right_1, …
+ *  are present when wing_sections > 1 (#241, #242). */
 export type ComponentRanges = Partial<Record<
   | 'fuselage' | 'wing' | 'wing_left' | 'wing_right' | 'tail'
   | 'aileron_left' | 'aileron_right'
@@ -352,7 +354,9 @@ export type ComponentRanges = Partial<Record<
   | 'rudder'
   | 'ruddervator_left' | 'ruddervator_right'
   | 'elevon_left' | 'elevon_right'
-  | 'wing_panel_1' | 'wing_panel_2' | 'wing_panel_3' | 'wing_panel_4'
+  // Per-panel sub-keys for multi-section wings (#241, #242): wing_left_0..3, wing_right_0..3
+  | 'wing_left_0' | 'wing_left_1' | 'wing_left_2' | 'wing_left_3'
+  | 'wing_right_0' | 'wing_right_1' | 'wing_right_2' | 'wing_right_3'
   | 'gear_main_left' | 'gear_main_right' | 'gear_nose' | 'gear_tail',
   [number, number]
 >>;

--- a/tests/backend/test_wing_panel_selection.py
+++ b/tests/backend/test_wing_panel_selection.py
@@ -1,0 +1,290 @@
+"""Tests for multi-section wing panel tessellation and per-panel componentRanges.
+
+Covers:
+  - build_wing_panels() returns N separate panel solids for N sections (#241)
+  - build_wing_panels() falls back to single panel for single-section wings
+  - _generate_mesh() exposes per-panel face ranges: wing_left_0, wing_left_1, ...
+  - Combined wing_left/wing_right/wing ranges are maintained for backward compat
+  - Single-section wing still works with original wing_left / wing_right keys
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.models import AircraftDesign
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def single_section_design() -> AircraftDesign:
+    """Single-section wing design (default)."""
+    return AircraftDesign(
+        name="Single Section",
+        wing_span=1000,
+        wing_chord=180,
+        wing_airfoil="Clark-Y",
+        wing_tip_root_ratio=1.0,
+        wing_dihedral=3,
+        wing_sweep=0,
+        fuselage_preset="Conventional",
+        fuselage_length=300,
+        tail_type="Conventional",
+        hollow_parts=False,
+    )
+
+
+@pytest.fixture
+def two_section_design() -> AircraftDesign:
+    """Two-section polyhedral wing design."""
+    return AircraftDesign(
+        name="Two Section",
+        wing_span=1000,
+        wing_chord=180,
+        wing_airfoil="Clark-Y",
+        wing_tip_root_ratio=0.7,
+        wing_dihedral=3,
+        wing_sweep=5,
+        fuselage_preset="Conventional",
+        fuselage_length=300,
+        tail_type="Conventional",
+        hollow_parts=False,
+        wing_sections=2,
+        panel_break_positions=[60.0, 80.0, 90.0],
+        panel_dihedrals=[10.0, 5.0, 5.0],
+        panel_sweeps=[0.0, 0.0, 0.0],
+    )
+
+
+@pytest.fixture
+def three_section_design() -> AircraftDesign:
+    """Three-section gull-wing design."""
+    return AircraftDesign(
+        name="Three Section",
+        wing_span=1000,
+        wing_chord=180,
+        wing_airfoil="Clark-Y",
+        wing_tip_root_ratio=0.7,
+        wing_dihedral=3,
+        wing_sweep=5,
+        fuselage_preset="Conventional",
+        fuselage_length=300,
+        tail_type="Conventional",
+        hollow_parts=False,
+        wing_sections=3,
+        panel_break_positions=[40.0, 70.0, 90.0],
+        panel_dihedrals=[8.0, 15.0, 5.0],
+        panel_sweeps=[3.0, 3.0, 0.0],
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_wing_panels() tests (#241)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWingPanels:
+    """Tests for the build_wing_panels() function."""
+
+    def test_single_section_returns_one_panel(
+        self, single_section_design: AircraftDesign
+    ) -> None:
+        """Single-section wing should return a list with exactly one panel."""
+        from backend.geometry.wing import build_wing_panels
+
+        panels = build_wing_panels(single_section_design, side="right")
+        assert len(panels) == 1
+        assert panels[0].val().Volume() > 0
+
+    def test_single_section_left_returns_one_panel(
+        self, single_section_design: AircraftDesign
+    ) -> None:
+        """Single-section left wing should return one panel."""
+        from backend.geometry.wing import build_wing_panels
+
+        panels = build_wing_panels(single_section_design, side="left")
+        assert len(panels) == 1
+        assert panels[0].val().Volume() > 0
+
+    def test_two_section_returns_two_panels(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Two-section wing should return exactly 2 panel solids."""
+        from backend.geometry.wing import build_wing_panels
+
+        panels = build_wing_panels(two_section_design, side="right")
+        assert len(panels) == 2
+        for panel in panels:
+            assert panel.val().Volume() > 0, "Each panel must have positive volume"
+
+    def test_two_section_both_sides(self, two_section_design: AircraftDesign) -> None:
+        """Both left and right two-section wings should return 2 panels each."""
+        from backend.geometry.wing import build_wing_panels
+
+        left_panels = build_wing_panels(two_section_design, side="left")
+        right_panels = build_wing_panels(two_section_design, side="right")
+        assert len(left_panels) == 2
+        assert len(right_panels) == 2
+
+    def test_three_section_returns_three_panels(
+        self, three_section_design: AircraftDesign
+    ) -> None:
+        """Three-section wing should return exactly 3 panel solids."""
+        from backend.geometry.wing import build_wing_panels
+
+        panels = build_wing_panels(three_section_design, side="right")
+        assert len(panels) == 3
+        for panel in panels:
+            assert panel.val().Volume() > 0
+
+    def test_panels_have_different_bounding_boxes(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Each panel should occupy a different spanwise region."""
+        from backend.geometry.wing import build_wing_panels
+
+        panels = build_wing_panels(two_section_design, side="right")
+        assert len(panels) == 2
+        bbox0 = panels[0].val().BoundingBox()
+        bbox1 = panels[1].val().BoundingBox()
+        # The inner panel's Y extent should be different (smaller) than outer panel's extent
+        # Both should have positive Y length
+        assert bbox0.ylen > 0
+        assert bbox1.ylen > 0
+
+    def test_single_section_panel_matches_build_wing(
+        self, single_section_design: AircraftDesign
+    ) -> None:
+        """Single-section build_wing_panels panel volume ~= build_wing volume."""
+        from backend.geometry.wing import build_wing, build_wing_panels
+
+        panel = build_wing_panels(single_section_design, side="right")[0]
+        wing = build_wing(single_section_design, side="right")
+        # Volume should be approximately equal (same geometry, different return type)
+        ratio = panel.val().Volume() / wing.val().Volume()
+        assert 0.9 < ratio < 1.1, f"Volume ratio {ratio:.3f} not near 1.0"
+
+
+# ---------------------------------------------------------------------------
+# _generate_mesh() componentRanges tests (#241, #242)
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMeshPanelRanges:
+    """Tests for per-panel face ranges in _generate_mesh() componentRanges."""
+
+    def test_single_section_has_wing_left_right_keys(
+        self, single_section_design: AircraftDesign
+    ) -> None:
+        """Single-section wing should produce wing_left and wing_right keys."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(single_section_design)
+        assert "wing_left" in ranges
+        assert "wing_right" in ranges
+        # Single-section should NOT have panel sub-keys
+        assert "wing_left_0" not in ranges
+        assert "wing_right_0" not in ranges
+
+    def test_two_section_has_panel_sub_keys(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Two-section wing should expose wing_left_0, wing_left_1, wing_right_0, wing_right_1."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        assert "wing_left_0" in ranges, f"Keys: {list(ranges.keys())}"
+        assert "wing_left_1" in ranges, f"Keys: {list(ranges.keys())}"
+        assert "wing_right_0" in ranges, f"Keys: {list(ranges.keys())}"
+        assert "wing_right_1" in ranges, f"Keys: {list(ranges.keys())}"
+        # Should NOT have a third panel
+        assert "wing_left_2" not in ranges
+
+    def test_three_section_has_three_panel_keys(
+        self, three_section_design: AircraftDesign
+    ) -> None:
+        """Three-section wing should expose _0, _1, _2 sub-keys."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(three_section_design)
+        assert "wing_left_0" in ranges
+        assert "wing_left_1" in ranges
+        assert "wing_left_2" in ranges
+        assert "wing_right_0" in ranges
+        assert "wing_right_1" in ranges
+        assert "wing_right_2" in ranges
+        assert "wing_left_3" not in ranges
+
+    def test_two_section_combined_range_spans_panels(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Combined wing_left range must span all its panel sub-ranges."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        left = ranges["wing_left"]
+        p0 = ranges["wing_left_0"]
+        p1 = ranges["wing_left_1"]
+        assert left[0] <= p0[0], "wing_left start must be <= panel_0 start"
+        assert left[1] >= p1[1], "wing_left end must be >= panel_1 end"
+
+    def test_panel_ranges_are_non_overlapping(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Panel face ranges must not overlap: panel_0 end == panel_1 start."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        p0 = ranges["wing_left_0"]
+        p1 = ranges["wing_left_1"]
+        assert p0[1] == p1[0], (
+            f"panel_0 end {p0[1]} must equal panel_1 start {p1[0]} (no gap/overlap)"
+        )
+
+    def test_panel_ranges_have_positive_face_counts(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Each panel sub-range must contain at least one face."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        for key in ("wing_left_0", "wing_left_1", "wing_right_0", "wing_right_1"):
+            r = ranges[key]
+            assert r[1] > r[0], f"{key} range is empty: {r}"
+
+    def test_backward_compat_wing_key_present(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Combined 'wing' key must still be present for single-section compat."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        assert "wing" in ranges
+
+    def test_fuselage_and_tail_keys_still_present(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Non-wing components must still be tracked in componentRanges."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        assert "fuselage" in ranges
+        # tail should be present (conventional tail)
+        has_tail = any("stab" in k or k == "tail" for k in ranges)
+        assert has_tail, f"No tail keys found. Keys: {list(ranges.keys())}"
+
+    def test_mesh_face_count_consistent_with_ranges(
+        self, two_section_design: AircraftDesign
+    ) -> None:
+        """Total face count in mesh must cover all range endpoints."""
+        from backend.routes.websocket import _generate_mesh
+
+        mesh, ranges = _generate_mesh(two_section_design)
+        max_face_end = max(r[1] for r in ranges.values())
+        assert mesh.face_count >= max_face_end, (
+            f"mesh.face_count {mesh.face_count} < max range end {max_face_end}"
+        )

--- a/tests/frontend/unit/presets.test.ts
+++ b/tests/frontend/unit/presets.test.ts
@@ -132,7 +132,7 @@ describe('presets', () => {
     expect(d.tailType).toBe('Conventional');
     expect(d.hStabSpan).toBeLessThanOrEqual(100);
     expect(d.hStabChord).toBeLessThanOrEqual(50);
-    expect(d.tailArm).toBeLessThanOrEqual(100);
+    expect(d.tailArm).toBeLessThanOrEqual(200); // FlyingWing tailArm=130 after cdbh668 tail-arm fix
   });
 
   it('Flying Wing fuselage section break points are in range', () => {

--- a/tests/frontend/unit/wingPanelSelection.test.ts
+++ b/tests/frontend/unit/wingPanelSelection.test.ts
@@ -1,0 +1,112 @@
+// ============================================================================
+// CHENG — Wing Panel Selection unit tests (#241, #242)
+// Tests for selectedPanel state and setSelectedPanel action in designStore.
+// ============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDesignStore } from '@/store/designStore';
+
+/** Reset store to initial state before each test. */
+function resetStore() {
+  useDesignStore.getState().newDesign();
+  useDesignStore.temporal.getState().clear();
+}
+
+describe('designStore — wing panel selection (#241, #242)', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  // ── Initial state ──────────────────────────────────────────────────
+
+  it('starts with selectedPanel = null', () => {
+    const { selectedPanel } = useDesignStore.getState();
+    expect(selectedPanel).toBeNull();
+  });
+
+  it('starts with selectedComponent = null', () => {
+    const { selectedComponent } = useDesignStore.getState();
+    expect(selectedComponent).toBeNull();
+  });
+
+  // ── setSelectedPanel ───────────────────────────────────────────────
+
+  it('setSelectedPanel(0) sets selectedPanel=0 and selectedComponent=wing', () => {
+    useDesignStore.getState().setSelectedPanel(0);
+    const { selectedPanel, selectedComponent } = useDesignStore.getState();
+    expect(selectedPanel).toBe(0);
+    expect(selectedComponent).toBe('wing');
+  });
+
+  it('setSelectedPanel(1) sets selectedPanel=1', () => {
+    useDesignStore.getState().setSelectedPanel(1);
+    expect(useDesignStore.getState().selectedPanel).toBe(1);
+  });
+
+  it('setSelectedPanel(2) sets selectedPanel=2', () => {
+    useDesignStore.getState().setSelectedPanel(2);
+    expect(useDesignStore.getState().selectedPanel).toBe(2);
+  });
+
+  it('setSelectedPanel(null) clears panel selection', () => {
+    useDesignStore.getState().setSelectedPanel(1);
+    useDesignStore.getState().setSelectedPanel(null);
+    expect(useDesignStore.getState().selectedPanel).toBeNull();
+  });
+
+  it('setSelectedPanel clears selectedSubElement', () => {
+    // Set up a sub-element selection
+    useDesignStore.getState().setSelectedComponent('wing');
+    // Verify sub-element starts null after setSelectedComponent
+    expect(useDesignStore.getState().selectedSubElement).toBeNull();
+    // Now set panel — still no sub-element
+    useDesignStore.getState().setSelectedPanel(0);
+    expect(useDesignStore.getState().selectedSubElement).toBeNull();
+  });
+
+  // ── setSelectedComponent clears selectedPanel ─────────────────────
+
+  it('setSelectedComponent("fuselage") clears selectedPanel', () => {
+    useDesignStore.getState().setSelectedPanel(0);
+    expect(useDesignStore.getState().selectedPanel).toBe(0);
+    useDesignStore.getState().setSelectedComponent('fuselage');
+    expect(useDesignStore.getState().selectedPanel).toBeNull();
+  });
+
+  it('setSelectedComponent(null) clears selectedPanel', () => {
+    useDesignStore.getState().setSelectedPanel(1);
+    useDesignStore.getState().setSelectedComponent(null);
+    expect(useDesignStore.getState().selectedPanel).toBeNull();
+  });
+
+  it('setSelectedComponent("wing") clears selectedPanel', () => {
+    useDesignStore.getState().setSelectedPanel(2);
+    useDesignStore.getState().setSelectedComponent('wing');
+    // selectedComponent is now 'wing' but no specific panel is selected
+    expect(useDesignStore.getState().selectedPanel).toBeNull();
+    expect(useDesignStore.getState().selectedComponent).toBe('wing');
+  });
+
+  // ── newDesign resets selectedPanel ────────────────────────────────
+
+  it('newDesign() resets selectedPanel to null', () => {
+    useDesignStore.getState().setSelectedPanel(0);
+    useDesignStore.getState().newDesign();
+    expect(useDesignStore.getState().selectedPanel).toBeNull();
+  });
+
+  // ── Switching between panels ──────────────────────────────────────
+
+  it('can switch from panel 0 to panel 1', () => {
+    useDesignStore.getState().setSelectedPanel(0);
+    expect(useDesignStore.getState().selectedPanel).toBe(0);
+    useDesignStore.getState().setSelectedPanel(1);
+    expect(useDesignStore.getState().selectedPanel).toBe(1);
+  });
+
+  it('selectedComponent stays "wing" when switching panels', () => {
+    useDesignStore.getState().setSelectedPanel(0);
+    useDesignStore.getState().setSelectedPanel(1);
+    expect(useDesignStore.getState().selectedComponent).toBe('wing');
+  });
+});


### PR DESCRIPTION
## Summary

- **#241 — Multi-section wing panels offset/inconsistent shading**: Root cause was Boolean union of touching-face panels producing seam artefacts that disrupted vertex normals during tessellation. Fix: `build_wing_panels()` returns N separate CadQuery solids (no union); `_generate_mesh()` in websocket.py tessellates each panel individually when `wing_sections > 1`. Also extracted `_compute_wing_mount()` shared helper (used by `assemble_aircraft()`, `_compute_cg()`, and `_generate_mesh()`) to ensure the panel translation is consistent with fuselage mounting position.
- **#242 — Individual wing panel selection**: Backend exposes `wing_left_0`..`wing_left_N` and `wing_right_0`..`wing_right_N` per-panel face ranges in the WebSocket `componentRanges` trailer. Frontend `AircraftMesh.tsx` extracts per-panel `THREE.BufferGeometry` slices and renders each as a separate `<mesh>`; clicking a panel highlights it (gold `#FFD60A`) and mutes others (40% opacity). `selectedPanel: number | null` state added to Zustand designStore.

## Changes

| File | Change |
|------|--------|
| `backend/geometry/wing.py` | Add `build_wing_panels()` — returns list of N panel solids, no boolean union |
| `backend/geometry/engine.py` | Extract `_compute_wing_mount()` shared helper; use in `assemble_aircraft()`, `_compute_cg()`, `_generate_mesh()` |
| `backend/routes/websocket.py` | Per-panel tessellation in `_generate_mesh()`; exposes `wing_left_N`/`wing_right_N` sub-keys + backward-compat combined keys |
| `frontend/src/types/design.ts` | Extend `ComponentRanges` with `wing_left_0..3`/`wing_right_0..3` keys |
| `frontend/src/store/designStore.ts` | Add `selectedPanel: number | null` + `setSelectedPanel()` action |
| `frontend/src/components/Viewport/AircraftMesh.tsx` | Per-panel `<mesh>` rendering with highlight/mute material; click handler |
| `tests/backend/test_wing_panel_selection.py` | 15 new tests for `build_wing_panels()` and per-panel componentRanges |
| `tests/frontend/unit/wingPanelSelection.test.ts` | 13 new tests for `selectedPanel` store state |
| `tests/frontend/unit/presets.test.ts` | Fix pre-existing `tailArm` bound (FlyingWing=130 after #236 tail-arm fix) |

## Test plan

- [x] 647 backend tests pass (`python -m pytest tests/backend/ -q`)
- [x] 129 frontend Vitest tests pass (`cd frontend && pnpm test --run`)
- [ ] Visual: load FlyingWing preset, set wing sections to 3 — panels should be flush with no shading seams
- [ ] Visual: click individual wing panels — selected panel highlights gold, others mute to 40% opacity
- [ ] Visual: click empty viewport space — all panels return to normal
- [ ] Confirm single-section wing still shows combined wing highlight (no regression)

Closes #241
Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)