### PR TITLE
fix(tooling): startup.ps1 error handling + docker-compose dev target (#274, #275)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   backend:
-    build: .
+    build:
+      context: .
+      target: dev-backend
     ports: ["8000:8000"]
     volumes:
       - ./backend:/app/backend


### PR DESCRIPTION
## Summary
- #274: `startup.ps1` — skip `pnpm build` by default for dev (add `-Build` flag for prod builds); check `$LASTEXITCODE` after `pnpm install` and exit on failure
- #275: Add `dev-backend` Dockerfile target that skips frontend build; `docker-compose.yml` uses this target to speed up dev rebuilds

## Test plan
- [ ] `.\startup.ps1` starts backend + Vite without running pnpm build
- [ ] `.\startup.ps1 -Build` still runs pnpm build before starting
- [ ] `pnpm install` failure prints error and aborts (test by temporarily breaking package.json)
- [ ] `docker compose up --build` with dev target completes significantly faster
- [ ] Backend still serves API correctly when built with dev target

Closes #274
Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)