### PR TITLE
fix(storage): atomic saves + unified EXPORT_TMP_DIR (#262, #263, #276)

### DIFF
--- a/backend/cleanup.py
+++ b/backend/cleanup.py
@@ -12,8 +12,9 @@ from pathlib import Path
 
 logger = logging.getLogger("cheng.cleanup")
 
-# Default temp directory — matches the export module's EXPORT_TMP_DIR.
-DEFAULT_TMP_DIR = Path("/data/tmp")
+# Authoritative temp directory — imported from the export module so that
+# cleanup and export always reference the same path (#262, #276).
+from backend.export.package import EXPORT_TMP_DIR as DEFAULT_TMP_DIR  # noqa: E402
 
 # Files older than this (seconds) are considered orphaned.
 MAX_AGE_SECONDS = 3600  # 1 hour

--- a/tests/backend/test_storage.py
+++ b/tests/backend/test_storage.py
@@ -1,13 +1,15 @@
 """Tests for the storage backend layer (LocalStorage).
 
 Covers edge cases like path traversal, missing files, corrupted JSON,
-and file permission errors.
+file permission errors, and atomic write behaviour.
 """
 
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -31,15 +33,11 @@ def test_safe_id_prevents_traversal() -> None:
         storage._safe_id("")
 
 
-def test_save_design_handles_io_error(tmp_storage: LocalStorage, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_save_design_handles_io_error(tmp_storage: LocalStorage) -> None:
     """save_design should bubble up OS/IO errors like disk full or permissions."""
-    def mock_write_text(*args, **kwargs):
-        raise OSError("No space left on device")
-
-    monkeypatch.setattr(Path, "write_text", mock_write_text)
-
-    with pytest.raises(OSError, match="No space left on device"):
-        tmp_storage.save_design("test-disk-full", {"id": "test-disk-full"})
+    with patch("os.replace", side_effect=OSError("No space left on device")):
+        with pytest.raises(OSError, match="No space left on device"):
+            tmp_storage.save_design("test-disk-full", {"id": "test-disk-full"})
 
 
 def test_load_design_not_found(tmp_storage: LocalStorage) -> None:
@@ -107,3 +105,82 @@ def test_delete_design_not_found(tmp_storage: LocalStorage) -> None:
     """delete_design should raise FileNotFoundError for missing files."""
     with pytest.raises(FileNotFoundError, match="Design not found: missing-id"):
         tmp_storage.delete_design("missing-id")
+
+
+# ---------------------------------------------------------------------------
+# Atomic write tests (#263)
+# ---------------------------------------------------------------------------
+
+
+def test_save_design_atomic_success(tmp_storage: LocalStorage) -> None:
+    """save_design should write correct JSON to the final file path."""
+    data = {"id": "atomic-ok", "name": "Atomic Test"}
+    tmp_storage.save_design("atomic-ok", data)
+
+    path = tmp_storage._path("atomic-ok")
+    assert path.exists()
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded == data
+
+
+def test_save_design_roundtrip(tmp_storage: LocalStorage) -> None:
+    """Data saved then loaded via load_design must be identical."""
+    data = {"id": "rt-001", "name": "Round-Trip", "wing_span": 1200}
+    tmp_storage.save_design("rt-001", data)
+    loaded = tmp_storage.load_design("rt-001")
+    assert loaded == data
+
+
+def test_save_design_atomic_crash_leaves_original_intact(tmp_storage: LocalStorage) -> None:
+    """If os.replace() raises mid-write the original file must be unchanged.
+
+    This simulates a crash after the temp file has been written but before the
+    atomic rename completes — the canonical scenario for #263.
+    """
+    original_data = {"id": "safe-001", "name": "Original"}
+    tmp_storage.save_design("safe-001", original_data)
+
+    # Confirm original is in place
+    path = tmp_storage._path("safe-001")
+    assert json.loads(path.read_text(encoding="utf-8")) == original_data
+
+    # Simulate crash during the atomic rename
+    with patch("os.replace", side_effect=OSError("Simulated crash")):
+        with pytest.raises(OSError, match="Simulated crash"):
+            tmp_storage.save_design("safe-001", {"id": "safe-001", "name": "Corrupted"})
+
+    # Original file must still be intact
+    assert json.loads(path.read_text(encoding="utf-8")) == original_data
+
+
+def test_save_design_atomic_cleans_up_tempfile_on_failure(tmp_storage: LocalStorage, tmp_path: Path) -> None:
+    """When os.replace() raises, the sibling .tmp_ file must be deleted."""
+    storage = LocalStorage(base_path=str(tmp_path))
+
+    with patch("os.replace", side_effect=OSError("Simulated crash")):
+        with pytest.raises(OSError):
+            storage.save_design("cleanup-test", {"id": "cleanup-test"})
+
+    # No leftover .tmp_ files should remain in the storage directory
+    leftover = list(tmp_path.glob(".tmp_*.json"))
+    assert leftover == [], f"Temp files not cleaned up: {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# Temp dir path consistency test (#262, #276)
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_and_export_use_same_tmp_dir() -> None:
+    """DEFAULT_TMP_DIR in cleanup.py must equal EXPORT_TMP_DIR in export/package.py.
+
+    This ensures the periodic cleanup daemon watches the same directory where
+    export functions write their temp ZIP files (#262, #276).
+    """
+    from backend.cleanup import DEFAULT_TMP_DIR
+    from backend.export.package import EXPORT_TMP_DIR
+
+    assert DEFAULT_TMP_DIR == EXPORT_TMP_DIR, (
+        f"cleanup.DEFAULT_TMP_DIR ({DEFAULT_TMP_DIR}) != "
+        f"export.EXPORT_TMP_DIR ({EXPORT_TMP_DIR})"
+    )


### PR DESCRIPTION
## Summary
- **#276 + #262**: Unify `EXPORT_TMP_DIR` — import the authoritative constant from `backend/export/package.py` in both `backend/cleanup.py` and `backend/main.py` so all three use the same path; the periodic cleanup daemon now correctly removes export temp files instead of watching the wrong directory
- **#263**: Make design saves atomic — write JSON to a sibling tempfile via `tempfile.mkstemp()` then `os.replace()` to prevent truncated/corrupt JSON on crash; cleans up the temp file if the rename fails

## Test plan
- [x] `test_cleanup_and_export_use_same_tmp_dir` — asserts `DEFAULT_TMP_DIR == EXPORT_TMP_DIR` at import time, preventing regressions
- [x] `test_save_design_atomic_crash_leaves_original_intact` — mocks `os.replace` to raise mid-write, verifies original file is unchanged
- [x] `test_save_design_atomic_cleans_up_tempfile_on_failure` — verifies no `.tmp_*.json` files remain after a failed save
- [x] `test_save_design_atomic_success` / `test_save_design_roundtrip` — normal save/load still works correctly
- [x] `test_save_design_handles_io_error` — updated to patch `os.replace` (the new code path)
- [x] All 654 backend tests pass

## Gemini Pro review
Clean approval. No CRITICAL/MAJOR issues. Confirmed: no circular import risk (unidirectional graph `main → cleanup → export/package → models`), `mkstemp(dir=target.parent)` ensures same-filesystem for atomic replace on Windows, fd closed before rename avoids PermissionError.

Closes #262
Closes #263
Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)