### PR TITLE
Parameter renaming for beginners

### DIFF
--- a/frontend/src/components/panels/FuselagePanel.tsx
+++ b/frontend/src/components/panels/FuselagePanel.tsx
@@ -1,6 +1,7 @@
 // ============================================================================
 // CHENG — Fuselage Panel: Fuselage geometry params + computed section lengths
 // Issue #120
+// Issue #154 — Parameter renaming for beginners (tooltips + label updates)
 // ============================================================================
 
 import React, { useCallback } from 'react';
@@ -126,6 +127,7 @@ export function FuselagePanel(): React.JSX.Element {
         options={FUSELAGE_PRESET_OPTIONS}
         onChange={setFuselagePreset}
         hasWarning={fieldHasWarning(warnings, 'fuselagePreset')}
+        title="Overall body shape. Pod = simple tube, Conventional = tapered body, Blended-Wing-Body = flying wing."
       />
 
       {/* F01 — Fuselage Length */}
@@ -140,6 +142,7 @@ export function FuselagePanel(): React.JSX.Element {
         onInputChange={setLengthInput}
         hasWarning={fieldHasWarning(warnings, 'fuselageLength')}
         warningText={warnText('fuselageLength')}
+        title="Length of the main body from nose to tail. Does not include spinner or tail overhang."
       />
 
       {/* P02 — Motor Config */}
@@ -149,15 +152,17 @@ export function FuselagePanel(): React.JSX.Element {
         options={MOTOR_CONFIG_OPTIONS}
         onChange={setMotorConfig}
         hasWarning={fieldHasWarning(warnings, 'motorConfig')}
+        title="Tractor = motor at the front pulling the plane. Pusher = motor at the back pushing the plane."
       />
 
-      {/* F13 — Wing Mount Type */}
+      {/* F13 — Wing Placement */}
       <ParamSelect
-        label="Wing Mount"
+        label="Wing Placement"
         value={design.wingMountType}
         options={WING_MOUNT_OPTIONS}
         onChange={setWingMountType}
         hasWarning={fieldHasWarning(warnings, 'wingMountType')}
+        title="Where the wing attaches to the fuselage. High-wing is easiest to build and most stable for beginners."
       />
 
       {/* ── Section Transition Points (F11/F12) ─────────────────────── */}
@@ -177,6 +182,7 @@ export function FuselagePanel(): React.JSX.Element {
         onInputChange={setNoseCabinBreakInput}
         hasWarning={fieldHasWarning(warnings, 'noseCabinBreakPct')}
         warningText={warnText('noseCabinBreakPct')}
+        title="Where the nose section ends and the main body begins, as % of total fuselage length."
       />
       <ParamSlider
         label="Cabin/Tail Break"
@@ -189,6 +195,7 @@ export function FuselagePanel(): React.JSX.Element {
         onInputChange={setCabinTailBreakInput}
         hasWarning={fieldHasWarning(warnings, 'cabinTailBreakPct')}
         warningText={warnText('cabinTailBreakPct')}
+        title="Where the main body ends and the tail section begins, as % of total fuselage length."
       />
 
       {/* Computed section length summary */}
@@ -216,6 +223,7 @@ export function FuselagePanel(): React.JSX.Element {
         onInputChange={setWallThicknessInput}
         hasWarning={fieldHasWarning(warnings, 'wallThickness')}
         warningText={warnText('wallThickness')}
+        title="Thickness of the printed fuselage shell. Thicker = stronger but heavier."
       />
 
       {/* ── Per-Component Print Settings (#128) ────────────────────── */}

--- a/frontend/src/components/panels/GlobalPanel.tsx
+++ b/frontend/src/components/panels/GlobalPanel.tsx
@@ -1,6 +1,7 @@
 // ============================================================================
 // CHENG — Global Panel: Core aircraft parameters
 // Issue #25 | #289 (preset section moved to Presets menu in Toolbar)
+// Issue #154 — Parameter renaming for beginners (tooltips added)
 // ============================================================================
 
 import React, { useCallback, useMemo, useState } from 'react';
@@ -158,10 +159,11 @@ export function GlobalPanel(): React.JSX.Element {
         options={FUSELAGE_PRESET_OPTIONS}
         onChange={setFuselagePreset}
         hasWarning={fieldHasWarning(warnings, 'fuselagePreset')}
+        title="Overall body shape. Pod = simple tube, Conventional = tapered body, Blended-Wing-Body = flying wing."
       />
 
       {/* G02 — Motor (toggle: engineCount 0 = no motor, 1 = single motor) */}
-      <div className="mb-3 flex items-center justify-between">
+      <div className="mb-3 flex items-center justify-between" title="Enable or disable the motor mount. Turn off for gliders.">
         <label
           htmlFor="motor-toggle"
           className="text-xs font-medium text-zinc-300 cursor-pointer"
@@ -202,6 +204,7 @@ export function GlobalPanel(): React.JSX.Element {
         options={MOTOR_CONFIG_OPTIONS}
         onChange={setMotorConfig}
         hasWarning={fieldHasWarning(warnings, 'motorConfig')}
+        title="Tractor = motor at the front pulling the plane. Pusher = motor at the back pushing the plane."
       />
 
       {/* G03 — Wing Span */}
@@ -216,6 +219,7 @@ export function GlobalPanel(): React.JSX.Element {
         onInputChange={setWingSpanInput}
         hasWarning={fieldHasWarning(warnings, 'wingSpan')}
         warningText={warnText('wingSpan')}
+        title="Total tip-to-tip wingspan. Most RC trainers are 900–1500 mm."
       />
 
       {/* G05 — Wing Chord / Aspect Ratio (bidirectional) */}
@@ -243,13 +247,14 @@ export function GlobalPanel(): React.JSX.Element {
         decimalsB={2}
       />
 
-      {/* F13 — Wing Mount Type */}
+      {/* F13 — Wing Placement */}
       <ParamSelect
-        label="Wing Mount"
+        label="Wing Placement"
         value={design.wingMountType}
         options={WING_MOUNT_OPTIONS}
         onChange={setWingMountType}
         hasWarning={fieldHasWarning(warnings, 'wingMountType')}
+        title="Where the wing attaches to the fuselage. High-wing is easiest to build and most stable for beginners."
       />
 
       {/* F01 — Fuselage Length */}
@@ -264,6 +269,7 @@ export function GlobalPanel(): React.JSX.Element {
         onInputChange={setFuselageLengthInput}
         hasWarning={fieldHasWarning(warnings, 'fuselageLength')}
         warningText={warnText('fuselageLength')}
+        title="Length of the main body from nose to tail. Does not include spinner or tail overhang."
       />
 
       {/* G06 — Tail Type */}
@@ -273,6 +279,7 @@ export function GlobalPanel(): React.JSX.Element {
         options={TAIL_TYPE_OPTIONS}
         onChange={setTailType}
         hasWarning={fieldHasWarning(warnings, 'tailType')}
+        title="Tail configuration. Conventional = horizontal + vertical stabilizers. V-Tail = two angled surfaces instead of separate H and V stabilizers."
       />
     </div>
   );

--- a/frontend/src/components/panels/TailConventionalPanel.tsx
+++ b/frontend/src/components/panels/TailConventionalPanel.tsx
@@ -2,6 +2,7 @@
 // CHENG — Tail Conventional Panel: H-stab + V-stab params
 // Used for Conventional, T-Tail, and Cruciform tail types
 // Issue #27, #144 (control surfaces)
+// Issue #154 — Parameter renaming for beginners
 // ============================================================================
 
 import React, { useCallback } from 'react';
@@ -120,7 +121,7 @@ export function TailConventionalPanel(): React.JSX.Element {
     [setParam],
   );
 
-  // ── Tail Arm handler ──────────────────────────────────────────────
+  // ── Tail Distance handler ─────────────────────────────────────────
 
   const setTailArmSlider = useCallback(
     (v: number) => setParam('tailArm', v, 'slider'),
@@ -157,6 +158,7 @@ export function TailConventionalPanel(): React.JSX.Element {
         onInputChange={setHStabSpanInput}
         hasWarning={fieldHasWarning(warnings, 'hStabSpan')}
         warningText={warnText('hStabSpan')}
+        title="Total tip-to-tip span of the horizontal stabilizer."
       />
 
       {/* T03 — H-Stab Chord */}
@@ -171,11 +173,12 @@ export function TailConventionalPanel(): React.JSX.Element {
         onInputChange={setHStabChordInput}
         hasWarning={fieldHasWarning(warnings, 'hStabChord')}
         warningText={warnText('hStabChord')}
+        title="Width of the horizontal stabilizer from leading edge to trailing edge."
       />
 
-      {/* T06 — H-Stab Incidence */}
+      {/* T06 — H-Stab Tilt Angle (formerly "H-Stab Incidence") */}
       <ParamSlider
-        label="H-Stab Incidence"
+        label="H-Stab Tilt Angle"
         unit="deg"
         value={design.hStabIncidence}
         min={-5}
@@ -184,6 +187,7 @@ export function TailConventionalPanel(): React.JSX.Element {
         onSliderChange={setHStabIncidenceSlider}
         onInputChange={setHStabIncidenceInput}
         hasWarning={fieldHasWarning(warnings, 'hStabIncidence')}
+        title="Pitch angle of the horizontal stabilizer relative to the fuselage. Usually left at 0."
       />
 
       {/* ── Elevator (C11-C13) ─────────────────────────────────────── */}
@@ -243,6 +247,7 @@ export function TailConventionalPanel(): React.JSX.Element {
         onSliderChange={setVStabHeightSlider}
         onInputChange={setVStabHeightInput}
         hasWarning={fieldHasWarning(warnings, 'vStabHeight')}
+        title="Height of the vertical stabilizer (fin) from root to tip."
       />
 
       {/* T10 — V-Stab Root Chord */}
@@ -256,6 +261,7 @@ export function TailConventionalPanel(): React.JSX.Element {
         onSliderChange={setVStabRootChordSlider}
         onInputChange={setVStabRootChordInput}
         hasWarning={fieldHasWarning(warnings, 'vStabRootChord')}
+        title="Width of the vertical stabilizer at the base, from leading edge to trailing edge."
       />
 
       {/* ── Rudder (C15-C17) ───────────────────────────────────────── */}
@@ -301,9 +307,9 @@ export function TailConventionalPanel(): React.JSX.Element {
       {/* ── Shared ─────────────────────────────────────────────────── */}
       <div className="border-t border-zinc-700/50 mt-3 mb-2" />
 
-      {/* T22 — Tail Arm */}
+      {/* T22 — Tail Distance (formerly "Tail Arm") */}
       <ParamSlider
-        label="Tail Arm"
+        label="Tail Distance"
         unit="mm"
         value={design.tailArm}
         min={80}
@@ -313,6 +319,7 @@ export function TailConventionalPanel(): React.JSX.Element {
         onInputChange={setTailArmInput}
         hasWarning={fieldHasWarning(warnings, 'tailArm')}
         warningText={warnText('tailArm')}
+        title="Distance from the wing to the tail. Longer = more stable but heavier."
       />
 
       {/* ── Per-Component Print Settings (#128) ────────────────────── */}

--- a/frontend/src/components/panels/TailVTailPanel.tsx
+++ b/frontend/src/components/panels/TailVTailPanel.tsx
@@ -2,6 +2,7 @@
 // CHENG — Tail V-Tail Panel: V-tail specific parameters
 // Shown when tailType === 'V-Tail'
 // Issue #27, #144 (control surfaces — ruddervators)
+// Issue #154 — Parameter renaming for beginners
 // ============================================================================
 
 import React, { useCallback } from 'react';
@@ -86,7 +87,7 @@ export function TailVTailPanel(): React.JSX.Element {
     [setParam],
   );
 
-  // ── Tail Arm handler ──────────────────────────────────────────────
+  // ── Tail Distance handler ─────────────────────────────────────────
 
   const setTailArmSlider = useCallback(
     (v: number) => setParam('tailArm', v, 'slider'),
@@ -106,9 +107,9 @@ export function TailVTailPanel(): React.JSX.Element {
         Tail &mdash; V-Tail
       </h3>
 
-      {/* T14 — V-Tail Dihedral */}
+      {/* T14 — V-Tail Tilt (formerly "V-Tail Dihedral") */}
       <ParamSlider
-        label="V-Tail Dihedral"
+        label="V-Tail Tilt"
         unit="deg"
         value={design.vTailDihedral}
         min={20}
@@ -117,6 +118,7 @@ export function TailVTailPanel(): React.JSX.Element {
         onSliderChange={setVTailDihedralSlider}
         onInputChange={setVTailDihedralInput}
         hasWarning={fieldHasWarning(warnings, 'vTailDihedral')}
+        title="How far the V-tail surfaces are tilted from horizontal. Higher values = more V-shaped."
       />
 
       {/* T16 — V-Tail Span */}
@@ -130,6 +132,7 @@ export function TailVTailPanel(): React.JSX.Element {
         onSliderChange={setVTailSpanSlider}
         onInputChange={setVTailSpanInput}
         hasWarning={fieldHasWarning(warnings, 'vTailSpan')}
+        title="Total tip-to-tip span of the V-tail surfaces."
       />
 
       {/* T17 — V-Tail Chord */}
@@ -143,11 +146,12 @@ export function TailVTailPanel(): React.JSX.Element {
         onSliderChange={setVTailChordSlider}
         onInputChange={setVTailChordInput}
         hasWarning={fieldHasWarning(warnings, 'vTailChord')}
+        title="Width of each V-tail surface from leading edge to trailing edge."
       />
 
-      {/* T18 — V-Tail Incidence */}
+      {/* T18 — V-Tail Angle (formerly "V-Tail Incidence") */}
       <ParamSlider
-        label="V-Tail Incidence"
+        label="V-Tail Angle"
         unit="deg"
         value={design.vTailIncidence}
         min={-3}
@@ -156,6 +160,7 @@ export function TailVTailPanel(): React.JSX.Element {
         onSliderChange={setVTailIncidenceSlider}
         onInputChange={setVTailIncidenceInput}
         hasWarning={fieldHasWarning(warnings, 'vTailIncidence')}
+        title="Pitch angle of the V-tail surfaces relative to the fuselage. Usually left at 0."
       />
 
       {/* T15 — V-Tail Sweep */}
@@ -169,6 +174,7 @@ export function TailVTailPanel(): React.JSX.Element {
         onSliderChange={setVTailSweepSlider}
         onInputChange={setVTailSweepInput}
         hasWarning={fieldHasWarning(warnings, 'vTailSweep')}
+        title="How far the leading edge of the V-tail is swept back."
       />
 
       {/* ── Ruddervators (C18-C20) ─────────────────────────────────── */}
@@ -217,9 +223,9 @@ export function TailVTailPanel(): React.JSX.Element {
       {/* ── Shared ─────────────────────────────────────────────────── */}
       <div className="border-t border-zinc-700/50 mt-3 mb-2" />
 
-      {/* T22 — Tail Arm */}
+      {/* T22 — Tail Distance (formerly "Tail Arm") */}
       <ParamSlider
-        label="Tail Arm"
+        label="Tail Distance"
         unit="mm"
         value={design.tailArm}
         min={80}
@@ -229,6 +235,7 @@ export function TailVTailPanel(): React.JSX.Element {
         onInputChange={setTailArmInput}
         hasWarning={fieldHasWarning(warnings, 'tailArm')}
         warningText={warnText('tailArm')}
+        title="Distance from the wing to the tail. Longer = more stable but heavier."
       />
 
       {/* ── Per-Component Print Settings (#128) ────────────────────── */}

--- a/frontend/src/components/panels/WingPanel.tsx
+++ b/frontend/src/components/panels/WingPanel.tsx
@@ -1,6 +1,7 @@
 // ============================================================================
 // CHENG — Wing Panel: Wing geometry + airfoil selection + derived values
 // Issue #26 | Multi-section wings #143 | Control surfaces #144
+// Issue #154 — Parameter renaming for beginners
 // ============================================================================
 
 import React, { useState, useCallback } from 'react';
@@ -132,7 +133,7 @@ function WingPanelSection({ index }: WingPanelSectionProps): React.JSX.Element {
             step={0.5}
             onSliderChange={setDihedral}
             onInputChange={setDihedral}
-            title={`Dihedral of panel ${index + 2}, measured from horizontal`}
+            title={`How much panel ${index + 2} tilts upward from horizontal. Positive = tips up.`}
           />
 
           {/* Outer Sweep */}
@@ -196,7 +197,7 @@ export function WingPanel(): React.JSX.Element {
     [setParam],
   );
 
-  // ── Wing Sections stepper (#243) ────────────────────────────────────
+  // ── Wing Panels stepper (#243) ───────────────────────────────────────
   const wingSections = design.wingSections;
   const decrementSections = useCallback(
     () => setParam('wingSections', Math.max(1, wingSections - 1), 'immediate'),
@@ -341,12 +342,12 @@ export function WingPanel(): React.JSX.Element {
         hasWarning={fieldHasWarning(warnings, 'wingAirfoil')}
       />
 
-      {/* W08 — Wing Sections stepper (#243) */}
+      {/* W08 — Wing Panels stepper (#243, renamed from Wing Sections in #154) */}
       <div
         className="flex items-center justify-between mb-2"
-        title="Number of spanwise wing panels per half. 1 = straight, 2–4 = polyhedral or cranked planform."
+        title="Number of spanwise panels per half-wing. 1 = straight wing, 2–4 = polyhedral or cranked planform."
       >
-        <span className="text-xs text-zinc-300">Wing Sections</span>
+        <span className="text-xs text-zinc-300">Wing Panels</span>
         <div className="flex items-center gap-1">
           <button
             type="button"
@@ -355,7 +356,7 @@ export function WingPanel(): React.JSX.Element {
             className="w-6 h-6 flex items-center justify-center rounded
               bg-zinc-700 hover:bg-zinc-600 disabled:opacity-40 disabled:cursor-not-allowed
               text-zinc-200 text-sm font-bold transition-colors focus:outline-none focus:ring-1 focus:ring-blue-500"
-            aria-label="Decrease wing sections"
+            aria-label="Decrease wing panels"
           >
             −
           </button>
@@ -369,7 +370,7 @@ export function WingPanel(): React.JSX.Element {
             className="w-6 h-6 flex items-center justify-center rounded
               bg-zinc-700 hover:bg-zinc-600 disabled:opacity-40 disabled:cursor-not-allowed
               text-zinc-200 text-sm font-bold transition-colors focus:outline-none focus:ring-1 focus:ring-blue-500"
-            aria-label="Increase wing sections"
+            aria-label="Increase wing panels"
           >
             +
           </button>
@@ -388,11 +389,12 @@ export function WingPanel(): React.JSX.Element {
         onInputChange={setSweepInput}
         hasWarning={fieldHasWarning(warnings, 'wingSweep')}
         warningText={warnText('wingSweep')}
+        title="How far the wing is swept back. 0 = straight, positive = swept back (like a jet)."
       />
 
-      {/* W04 — Wing Tip/Root Ratio */}
+      {/* W04 — Wing Taper (Tip/Root Ratio) */}
       <ParamSlider
-        label="Tip/Root Chord Ratio"
+        label="Taper (Tip/Root)"
         unit="ratio"
         value={design.wingTipRootRatio}
         min={0.3}
@@ -402,7 +404,7 @@ export function WingPanel(): React.JSX.Element {
         onInputChange={setTipRootInput}
         hasWarning={fieldHasWarning(warnings, 'wingTipRootRatio')}
         warningText={warnText('wingTipRootRatio')}
-        title="1.0 = rectangular wing, lower values = more tapered toward the tip"
+        title="How much the wing narrows from root to tip. 1.0 = rectangular (same width tip to root), lower = more tapered."
       />
 
       {/* W07 — Wing Dihedral (panel 1) */}
@@ -417,11 +419,12 @@ export function WingPanel(): React.JSX.Element {
         onInputChange={setDihedralInput}
         hasWarning={fieldHasWarning(warnings, 'wingDihedral')}
         warningText={warnText('wingDihedral')}
+        title="How much the wings angle upward from root to tip. Positive = tips up. Improves stability."
       />
 
-      {/* W08 — Wing Incidence */}
+      {/* W06 — Wing Angle (incidence) */}
       <ParamSlider
-        label="Incidence"
+        label="Wing Angle"
         unit="deg"
         value={design.wingIncidence}
         min={-5}
@@ -430,11 +433,12 @@ export function WingPanel(): React.JSX.Element {
         onSliderChange={setIncidenceSlider}
         onInputChange={setIncidenceInput}
         hasWarning={fieldHasWarning(warnings, 'wingIncidence')}
+        title="Tilts the wing up or down relative to the fuselage. Positive = front of wing tilts up. Most planes use 1–3 degrees."
       />
 
-      {/* W06 — Wing Twist (washout) */}
+      {/* W16 — Tip Twist (washout) */}
       <ParamSlider
-        label="Twist (washout)"
+        label="Tip Twist"
         unit="deg"
         value={design.wingTwist}
         min={-5}
@@ -443,7 +447,7 @@ export function WingPanel(): React.JSX.Element {
         onSliderChange={setTwistSlider}
         onInputChange={setTwistInput}
         hasWarning={fieldHasWarning(warnings, 'wingTwist')}
-        title="Negative = washout (tip nose-down), positive = washin"
+        title="Twists the wing tip compared to the root. Negative = tip nose-down (washout), which prevents tip stalls. Positive = washin."
       />
 
       {/* W20 — Wing Skin Thickness */}
@@ -458,6 +462,7 @@ export function WingPanel(): React.JSX.Element {
         onInputChange={setSkinInput}
         hasWarning={fieldHasWarning(warnings, 'wingSkinThickness')}
         warningText={warnText('wingSkinThickness')}
+        title="Thickness of the printed wing shell. Thicker = stronger but heavier."
       />
 
       {/* ── Control Surfaces (Issue #144) ─────────────────────────── */}
@@ -487,6 +492,7 @@ export function WingPanel(): React.JSX.Element {
             onInputChange={setElevonSpanStartInput}
             disabled={!design.elevonEnable}
             hasWarning={fieldHasWarning(warnings, 'elevonSpanStart')}
+            title="Inner edge of the elevon surface as % of half-span from root."
           />
           <ParamSlider
             label="Elevon Outboard"
@@ -499,6 +505,7 @@ export function WingPanel(): React.JSX.Element {
             onInputChange={setElevonSpanEndInput}
             disabled={!design.elevonEnable}
             hasWarning={fieldHasWarning(warnings, 'elevonSpanEnd')}
+            title="Outer edge of the elevon surface as % of half-span."
           />
           <ParamSlider
             label="Elevon Chord %"
@@ -593,28 +600,33 @@ export function WingPanel(): React.JSX.Element {
         value={derived?.tipChordMm ?? null}
         unit="mm"
         decimals={1}
+        title="Calculated wing width at the tip, based on root chord and taper ratio."
       />
       <DerivedField
         label="Wing Area"
         value={derived?.wingAreaCm2 ?? null}
         unit="cm&#178;"
         decimals={1}
+        title="Total planform area of both wings combined."
       />
       <DerivedField
         label="Aspect Ratio"
         value={derived?.aspectRatio ?? null}
         decimals={2}
+        title="How long and narrow the wing is. Higher = more efficient glide, lower = more agile. Wingspan divided by average chord."
       />
       <DerivedField
-        label="Mean Aero Chord"
+        label="Avg. Wing Width (MAC)"
         value={derived?.meanAeroChordMm ?? null}
         unit="mm"
         decimals={1}
+        title="Mean Aerodynamic Chord — the average width of the wing, used to calculate CG position."
       />
       <DerivedField
         label="Taper Ratio"
         value={derived?.taperRatio ?? null}
         decimals={3}
+        title="Tip chord divided by root chord. Same as the Taper (Tip/Root) setting above."
       />
       <DerivedField
         label="Estimated CG"
@@ -622,6 +634,7 @@ export function WingPanel(): React.JSX.Element {
         unit="mm"
         decimals={1}
         suffix="from wing LE"
+        title="Estimated balance point (center of gravity) measured from the wing leading edge."
       />
 
       {/* ── Per-Component Print Settings (#128) ────────────────────── */}

--- a/frontend/src/components/ui/DerivedField.tsx
+++ b/frontend/src/components/ui/DerivedField.tsx
@@ -1,5 +1,6 @@
 // ============================================================================
 // CHENG — Read-Only Derived Value Display
+// Issue #154 — Added title prop for hover tooltips
 // ============================================================================
 
 import React from 'react';
@@ -15,6 +16,8 @@ export interface DerivedFieldProps {
   decimals?: number;
   /** Optional suffix text after unit (e.g. "from wing LE") */
   suffix?: string;
+  /** Optional hover tooltip explaining what this value means */
+  title?: string;
 }
 
 /**
@@ -28,6 +31,7 @@ export function DerivedField({
   unit,
   decimals = 1,
   suffix,
+  title,
 }: DerivedFieldProps): React.JSX.Element {
   let formatted: string;
   if (value == null) {
@@ -38,7 +42,7 @@ export function DerivedField({
   }
 
   return (
-    <div className="mb-2">
+    <div className="mb-2" title={title}>
       <span className="block text-xs font-medium text-zinc-400 mb-0.5">{label}</span>
       <div
         className="w-full px-2 py-1 text-xs text-zinc-300 bg-zinc-800/50


### PR DESCRIPTION
## Summary

Renames technical aerospace terminology to plain-English labels in all UI parameter panels, making the tool more accessible to hobby RC builders without an aviation background.

## Related Issue

Closes #154

## Changes

- **WingPanel.tsx:**
  - "Wing Sections" -> "Wing Panels" (RC builders call these panels, not sections)
  - "Incidence" -> "Wing Angle" (with tooltip: tilts wing up/down relative to fuselage)
  - "Twist (washout)" -> "Tip Twist" (with tooltip: twist tip down to prevent tip stalls)
  - "Tip/Root Chord Ratio" -> "Taper (Tip/Root)" (taper is the common term)
  - "Mean Aero Chord" derived label -> "Avg. Wing Width (MAC)" (plain English + acronym)
  - Added tooltips to all wing parameters and computed values

- **TailVTailPanel.tsx:**
  - "V-Tail Dihedral" -> "V-Tail Tilt" (with tooltip explaining tilt angle)
  - "V-Tail Incidence" -> "V-Tail Angle" (with tooltip)
  - "Tail Arm" -> "Tail Distance" (with tooltip: distance from wing to tail)
  - Added tooltips to all V-tail parameters

- **TailConventionalPanel.tsx:**
  - "H-Stab Incidence" -> "H-Stab Tilt Angle" (consistent with V-tail naming)
  - "Tail Arm" -> "Tail Distance" (same as V-tail panel)
  - Added tooltips to all conventional tail parameters

- **GlobalPanel.tsx:**
  - "Wing Mount" -> "Wing Placement" (more natural phrasing)
  - Added tooltips to all global parameters (wingspan, fuselage style, motor position, etc.)

- **FuselagePanel.tsx:**
  - "Wing Mount" -> "Wing Placement" (consistent with GlobalPanel)
  - Added tooltips to all fuselage parameters

- **DerivedField.tsx:**
  - Added optional `title` prop to support hover tooltips on computed value fields

All internal field names (camelCase: `wingIncidence`, `tailArm`, `vTailDihedral`, etc.) remain unchanged — only the UI display labels are updated. No API or backend changes required.

## Gemini Peer Review

Gemini reviewed the diff and confirmed:
- Parameter renames are applied consistently across all panels
- `title` prop is correctly supported by `ParamSlider`, `ParamSelect`, and `DerivedField`
- Tooltips strike a good balance between technical accuracy and accessibility
- Code follows existing patterns with no logic or bug issues

Status: **Approved with no issues**
Cycles used: 1 of 3

## Testing

- Frontend Vitest: 217 passing (1 pre-existing failure in responsiveLayout for issue #157, unrelated to this change)
- All parameter rename changes are purely cosmetic UI labels — no logic changes, no backend impact
- Labels verified against cross_review_ux.md Section 5 and Section 6 recommendations