### PR TITLE
feat(ux): configurable print bed size with localStorage persistence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useDesignSync } from '@/hooks/useDesignSync';
 import { useConnectionStore } from '@/store/connectionStore';
 import { useChengMode } from '@/hooks/useChengMode';
 import { useIndexedDbPersistence } from '@/hooks/useIndexedDbPersistence';
+import { usePrintBedPreferences } from '@/hooks/usePrintBedPreferences';
 import { Toolbar } from '@/components/Toolbar';
 import Scene from '@/components/Viewport/Scene';
 import { ComponentPanel } from '@/components/panels/ComponentPanel';
@@ -51,6 +52,12 @@ export default function App() {
 
   // Enable IndexedDB auto-save + restore in cloud mode
   useIndexedDbPersistence(isCloudMode);
+
+  // Issue #155: load + apply saved print bed preferences on startup.
+  // The hook returns helpers that are passed down to the ExportDialog via
+  // the exportOpen state (the dialog reads them from context / callback props).
+  const { saveAsDefault: saveBedAsDefault, resetToDefaults: resetBedToDefaults } =
+    usePrintBedPreferences();
 
   const [exportOpen, setExportOpen] = useState(false);
   const isConnected = useConnectionStore((s) => s.state === 'connected');
@@ -137,7 +144,12 @@ export default function App() {
       </footer>
 
       {/* Modal overlay */}
-      <ExportDialog open={exportOpen} onOpenChange={setExportOpen} />
+      <ExportDialog
+        open={exportOpen}
+        onOpenChange={setExportOpen}
+        onSaveBedAsDefault={saveBedAsDefault}
+        onResetBedToDefaults={resetBedToDefaults}
+      />
     </div>
   );
 }

--- a/frontend/src/hooks/usePrintBedPreferences.ts
+++ b/frontend/src/hooks/usePrintBedPreferences.ts
@@ -1,0 +1,82 @@
+// ============================================================================
+// CHENG — usePrintBedPreferences (Issue #155)
+//
+// Synchronises the active design's print bed dimensions with localStorage.
+//
+// Behaviour:
+// 1. On mount: loads saved prefs from localStorage and, if they are non-default,
+//    calls the store's applyBedPreferences() action to apply them to the active
+//    design without marking it as dirty.
+// 2. Returns { saveAsDefault, resetToDefaults } for the UI.
+//    - saveAsDefault(): saves current design bed dims to localStorage.
+//    - resetToDefaults(): clears saved prefs and restores factory defaults.
+//
+// The store's loadPreset() and newDesign() already call loadPrintBedPrefs()
+// internally, so preset loads also honour user preferences automatically.
+//
+// Usage: call once at App root level.
+// ============================================================================
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useDesignStore } from '@/store/designStore';
+import {
+  loadPrintBedPrefs,
+  savePrintBedPrefs,
+  clearPrintBedPrefs,
+  BED_DEFAULTS,
+  isDefaultPrintBedPrefs,
+} from '@/lib/printBedPrefs';
+
+/**
+ * Manages print bed preferences persistence.
+ *
+ * Returns helpers used by the ExportDialog's "Save as default" button.
+ */
+export function usePrintBedPreferences(): {
+  /** Save current design bed dims as the new user default. */
+  saveAsDefault: () => void;
+  /** Reset saved prefs to factory defaults and apply to current design. */
+  resetToDefaults: () => void;
+} {
+  const applyBedPreferences = useDesignStore((s) => s.applyBedPreferences);
+  const setParam = useDesignStore((s) => s.setParam);
+  const design = useDesignStore((s) => s.design);
+
+  // Ref so callbacks always see latest design without re-creating handlers.
+  const designRef = useRef(design);
+  useEffect(() => {
+    designRef.current = design;
+  });
+
+  // ── On mount: apply saved prefs to the initial design ──────────────────────
+  useEffect(() => {
+    // The store's applyBedPreferences() reads localStorage and applies saved
+    // bed dims without dirtying the design (no isDirty flag set).
+    applyBedPreferences();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Run once on mount only
+
+  // ── saveAsDefault: persist current bed dims ─────────────────────────────────
+  const saveAsDefault = useCallback(() => {
+    const { printBedX, printBedY, printBedZ } = designRef.current;
+    savePrintBedPrefs({ printBedX, printBedY, printBedZ });
+  }, []);
+
+  // ── resetToDefaults: clear prefs and apply factory defaults ────────────────
+  const resetToDefaults = useCallback(() => {
+    clearPrintBedPrefs();
+    // Apply factory defaults to the current design
+    setParam('printBedX', BED_DEFAULTS.printBedX, 'immediate');
+    setParam('printBedY', BED_DEFAULTS.printBedY, 'immediate');
+    setParam('printBedZ', BED_DEFAULTS.printBedZ, 'immediate');
+  }, [setParam]);
+
+  return {
+    saveAsDefault,
+    resetToDefaults,
+  };
+}
+
+// Explicitly re-export the type so it can be used by the ExportDialog without
+// a separate import from printBedPrefs.
+export { isDefaultPrintBedPrefs, loadPrintBedPrefs };

--- a/frontend/src/lib/printBedPrefs.ts
+++ b/frontend/src/lib/printBedPrefs.ts
@@ -1,0 +1,113 @@
+// ============================================================================
+// CHENG — Print Bed Preferences (Issue #155)
+//
+// Persists the user's printer bed dimensions in localStorage so they survive
+// across sessions and are not reset when loading presets or new designs.
+//
+// Design decisions:
+// - Stored in localStorage (not IndexedDB) — preferences are machine-local
+//   user data, not per-design. localStorage is synchronous and simpler.
+// - Key: "cheng-print-bed-prefs"
+// - Falls back to the CHENG defaults (220 / 220 / 250 mm) when nothing is
+//   stored or the stored value is malformed.
+// ============================================================================
+
+const STORAGE_KEY = 'cheng-print-bed-prefs';
+
+/** Default bed dimensions matching PRINT_DEFAULTS in presets.ts. */
+export const BED_DEFAULTS = {
+  printBedX: 220,
+  printBedY: 220,
+  printBedZ: 250,
+} as const;
+
+/** Minimum/maximum allowed bed dimensions (mirrors backend model constraints). */
+export const BED_CONSTRAINTS = {
+  printBedX: { min: 100, max: 500 },
+  printBedY: { min: 100, max: 500 },
+  printBedZ: { min: 50, max: 500 },
+} as const;
+
+/** Stored print bed preference values. */
+export interface PrintBedPrefs {
+  printBedX: number;
+  printBedY: number;
+  printBedZ: number;
+}
+
+/**
+ * Load print bed preferences from localStorage.
+ *
+ * Returns the stored values if present and valid, or the defaults otherwise.
+ * Never throws — storage errors are swallowed and the default is returned.
+ */
+export function loadPrintBedPrefs(): PrintBedPrefs {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...BED_DEFAULTS };
+
+    const parsed = JSON.parse(raw) as Partial<PrintBedPrefs>;
+
+    // Validate each field; fall back to default on invalid value
+    const x = _clampBed('printBedX', parsed.printBedX);
+    const y = _clampBed('printBedY', parsed.printBedY);
+    const z = _clampBed('printBedZ', parsed.printBedZ);
+
+    return { printBedX: x, printBedY: y, printBedZ: z };
+  } catch {
+    return { ...BED_DEFAULTS };
+  }
+}
+
+/**
+ * Save print bed preferences to localStorage.
+ *
+ * Silently ignores storage errors (private browsing, quota exceeded, etc.).
+ */
+export function savePrintBedPrefs(prefs: PrintBedPrefs): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Non-fatal — user can still use the app, prefs just won't persist.
+  }
+}
+
+/**
+ * Clear saved print bed preferences, resetting to defaults.
+ *
+ * Useful for tests and the "Reset to defaults" button.
+ */
+export function clearPrintBedPrefs(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Non-fatal
+  }
+}
+
+/**
+ * Return true when the given prefs match the built-in defaults exactly.
+ */
+export function isDefaultPrintBedPrefs(prefs: PrintBedPrefs): boolean {
+  return (
+    prefs.printBedX === BED_DEFAULTS.printBedX &&
+    prefs.printBedY === BED_DEFAULTS.printBedY &&
+    prefs.printBedZ === BED_DEFAULTS.printBedZ
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function _clampBed(
+  key: keyof typeof BED_CONSTRAINTS,
+  value: unknown,
+): number {
+  const { min, max } = BED_CONSTRAINTS[key];
+  const n = typeof value === 'number' ? value : NaN;
+  if (Number.isNaN(n) || n < min || n > max) {
+    return BED_DEFAULTS[key];
+  }
+  return n;
+}

--- a/tests/frontend/unit/printBedPrefs.test.ts
+++ b/tests/frontend/unit/printBedPrefs.test.ts
@@ -1,0 +1,202 @@
+// ============================================================================
+// CHENG — Print Bed Preferences unit tests (Issue #155)
+// ============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  loadPrintBedPrefs,
+  savePrintBedPrefs,
+  clearPrintBedPrefs,
+  isDefaultPrintBedPrefs,
+  BED_DEFAULTS,
+  type PrintBedPrefs,
+} from '@/lib/printBedPrefs';
+
+// ---------------------------------------------------------------------------
+// localStorage mock helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal synchronous localStorage mock for jsdom. */
+let _store: Record<string, string> = {};
+
+const mockLocalStorage = {
+  getItem: (key: string) => _store[key] ?? null,
+  setItem: (key: string, value: string) => { _store[key] = value; },
+  removeItem: (key: string) => { delete _store[key]; },
+  clear: () => { _store = {}; },
+};
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _store = {};
+  vi.stubGlobal('localStorage', mockLocalStorage);
+});
+
+// ---------------------------------------------------------------------------
+// BED_DEFAULTS
+// ---------------------------------------------------------------------------
+
+describe('BED_DEFAULTS', () => {
+  it('has the expected factory values', () => {
+    expect(BED_DEFAULTS.printBedX).toBe(220);
+    expect(BED_DEFAULTS.printBedY).toBe(220);
+    expect(BED_DEFAULTS.printBedZ).toBe(250);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPrintBedPrefs
+// ---------------------------------------------------------------------------
+
+describe('loadPrintBedPrefs', () => {
+  it('returns defaults when nothing is stored', () => {
+    const prefs = loadPrintBedPrefs();
+    expect(prefs).toEqual(BED_DEFAULTS);
+  });
+
+  it('returns stored values when valid prefs are present', () => {
+    const stored: PrintBedPrefs = { printBedX: 300, printBedY: 310, printBedZ: 350 };
+    mockLocalStorage.setItem('cheng-print-bed-prefs', JSON.stringify(stored));
+
+    const prefs = loadPrintBedPrefs();
+    expect(prefs.printBedX).toBe(300);
+    expect(prefs.printBedY).toBe(310);
+    expect(prefs.printBedZ).toBe(350);
+  });
+
+  it('clamps out-of-range X value to default', () => {
+    mockLocalStorage.setItem(
+      'cheng-print-bed-prefs',
+      JSON.stringify({ printBedX: 50, printBedY: 220, printBedZ: 250 }),
+    );
+    const prefs = loadPrintBedPrefs();
+    // 50 < 100 (min) -> falls back to default
+    expect(prefs.printBedX).toBe(220);
+  });
+
+  it('clamps out-of-range Y value to default', () => {
+    mockLocalStorage.setItem(
+      'cheng-print-bed-prefs',
+      JSON.stringify({ printBedX: 220, printBedY: 9999, printBedZ: 250 }),
+    );
+    const prefs = loadPrintBedPrefs();
+    // 9999 > 500 (max) -> falls back to default
+    expect(prefs.printBedY).toBe(220);
+  });
+
+  it('clamps out-of-range Z value to default', () => {
+    mockLocalStorage.setItem(
+      'cheng-print-bed-prefs',
+      JSON.stringify({ printBedX: 220, printBedY: 220, printBedZ: 10 }),
+    );
+    const prefs = loadPrintBedPrefs();
+    // 10 < 50 (min) -> falls back to default
+    expect(prefs.printBedZ).toBe(250);
+  });
+
+  it('falls back to defaults when JSON is malformed', () => {
+    mockLocalStorage.setItem('cheng-print-bed-prefs', 'not valid json {');
+    const prefs = loadPrintBedPrefs();
+    expect(prefs).toEqual(BED_DEFAULTS);
+  });
+
+  it('falls back to defaults when stored value is null/missing fields', () => {
+    mockLocalStorage.setItem('cheng-print-bed-prefs', JSON.stringify({}));
+    const prefs = loadPrintBedPrefs();
+    expect(prefs).toEqual(BED_DEFAULTS);
+  });
+
+  it('does not throw when localStorage throws', () => {
+    const throwingStorage = {
+      ...mockLocalStorage,
+      getItem: () => { throw new Error('Storage blocked'); },
+    };
+    vi.stubGlobal('localStorage', throwingStorage);
+    expect(() => loadPrintBedPrefs()).not.toThrow();
+    expect(loadPrintBedPrefs()).toEqual(BED_DEFAULTS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// savePrintBedPrefs
+// ---------------------------------------------------------------------------
+
+describe('savePrintBedPrefs', () => {
+  it('stores prefs in localStorage', () => {
+    savePrintBedPrefs({ printBedX: 400, printBedY: 400, printBedZ: 400 });
+    const raw = mockLocalStorage.getItem('cheng-print-bed-prefs');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!) as PrintBedPrefs;
+    expect(parsed.printBedX).toBe(400);
+    expect(parsed.printBedY).toBe(400);
+    expect(parsed.printBedZ).toBe(400);
+  });
+
+  it('overwrites previously stored prefs', () => {
+    savePrintBedPrefs({ printBedX: 300, printBedY: 300, printBedZ: 300 });
+    savePrintBedPrefs({ printBedX: 250, printBedY: 260, printBedZ: 270 });
+    const prefs = loadPrintBedPrefs();
+    expect(prefs.printBedX).toBe(250);
+    expect(prefs.printBedY).toBe(260);
+    expect(prefs.printBedZ).toBe(270);
+  });
+
+  it('does not throw when localStorage is unavailable', () => {
+    const throwingStorage = {
+      ...mockLocalStorage,
+      setItem: () => { throw new Error('Storage blocked'); },
+    };
+    vi.stubGlobal('localStorage', throwingStorage);
+    expect(() =>
+      savePrintBedPrefs({ printBedX: 300, printBedY: 300, printBedZ: 300 }),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearPrintBedPrefs
+// ---------------------------------------------------------------------------
+
+describe('clearPrintBedPrefs', () => {
+  it('removes stored prefs so next load returns defaults', () => {
+    savePrintBedPrefs({ printBedX: 350, printBedY: 350, printBedZ: 350 });
+    clearPrintBedPrefs();
+    expect(loadPrintBedPrefs()).toEqual(BED_DEFAULTS);
+  });
+
+  it('does not throw when nothing is stored', () => {
+    expect(() => clearPrintBedPrefs()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDefaultPrintBedPrefs
+// ---------------------------------------------------------------------------
+
+describe('isDefaultPrintBedPrefs', () => {
+  it('returns true for factory defaults', () => {
+    expect(isDefaultPrintBedPrefs({ ...BED_DEFAULTS })).toBe(true);
+  });
+
+  it('returns false when any dimension differs', () => {
+    expect(isDefaultPrintBedPrefs({ printBedX: 300, printBedY: 220, printBedZ: 250 })).toBe(false);
+    expect(isDefaultPrintBedPrefs({ printBedX: 220, printBedY: 300, printBedZ: 250 })).toBe(false);
+    expect(isDefaultPrintBedPrefs({ printBedX: 220, printBedY: 220, printBedZ: 300 })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: save then load
+// ---------------------------------------------------------------------------
+
+describe('round-trip', () => {
+  it('save + load returns identical values', () => {
+    const original: PrintBedPrefs = { printBedX: 180, printBedY: 220, printBedZ: 500 };
+    savePrintBedPrefs(original);
+    const loaded = loadPrintBedPrefs();
+    expect(loaded).toEqual(original);
+  });
+});

--- a/tests/frontend/unit/printBedPrefsIntegration.test.ts
+++ b/tests/frontend/unit/printBedPrefsIntegration.test.ts
@@ -1,0 +1,143 @@
+// ============================================================================
+// CHENG — Print Bed Preferences integration tests (Issue #155)
+//
+// Tests the interaction between printBedPrefs.ts and the designStore.
+// ============================================================================
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useDesignStore } from '@/store/designStore';
+import {
+  savePrintBedPrefs,
+  clearPrintBedPrefs,
+  BED_DEFAULTS,
+} from '@/lib/printBedPrefs';
+
+// ---------------------------------------------------------------------------
+// localStorage mock (same pattern as printBedPrefs.test.ts)
+// ---------------------------------------------------------------------------
+
+let _store: Record<string, string> = {};
+
+const mockLocalStorage = {
+  getItem: (key: string) => _store[key] ?? null,
+  setItem: (key: string, value: string) => { _store[key] = value; },
+  removeItem: (key: string) => { delete _store[key]; },
+  clear: () => { _store = {}; },
+};
+
+// ---------------------------------------------------------------------------
+// Reset helpers
+// ---------------------------------------------------------------------------
+
+function resetStore(): void {
+  useDesignStore.getState().newDesign();
+  useDesignStore.temporal.getState().clear();
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _store = {};
+  vi.stubGlobal('localStorage', mockLocalStorage);
+  resetStore();
+});
+
+// ---------------------------------------------------------------------------
+// applyBedPreferences
+// ---------------------------------------------------------------------------
+
+describe('designStore.applyBedPreferences', () => {
+  it('does not change bed dims when no prefs are saved (default prefs)', () => {
+    // No saved prefs — defaults should remain
+    const before = useDesignStore.getState().design;
+    useDesignStore.getState().applyBedPreferences();
+    const after = useDesignStore.getState().design;
+
+    expect(after.printBedX).toBe(before.printBedX);
+    expect(after.printBedY).toBe(before.printBedY);
+    expect(after.printBedZ).toBe(before.printBedZ);
+  });
+
+  it('applies non-default saved prefs to the active design', () => {
+    // Save custom prefs
+    savePrintBedPrefs({ printBedX: 300, printBedY: 310, printBedZ: 400 });
+
+    useDesignStore.getState().applyBedPreferences();
+    const { design } = useDesignStore.getState();
+
+    expect(design.printBedX).toBe(300);
+    expect(design.printBedY).toBe(310);
+    expect(design.printBedZ).toBe(400);
+  });
+
+  it('does not mark design as dirty when applying prefs', () => {
+    savePrintBedPrefs({ printBedX: 350, printBedY: 350, printBedZ: 350 });
+    useDesignStore.getState().applyBedPreferences();
+
+    // isDirty should NOT be set — bed prefs are not user design edits
+    expect(useDesignStore.getState().isDirty).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadPreset + bed prefs
+// ---------------------------------------------------------------------------
+
+describe('designStore.loadPreset with saved bed prefs', () => {
+  it('preserves saved custom bed dims when loading a preset', () => {
+    // Save custom prefs
+    savePrintBedPrefs({ printBedX: 350, printBedY: 350, printBedZ: 300 });
+
+    // Load a different preset
+    useDesignStore.getState().loadPreset('Sport');
+    const { design } = useDesignStore.getState();
+
+    // Bed dims should be the saved prefs, not the preset's defaults
+    expect(design.printBedX).toBe(350);
+    expect(design.printBedY).toBe(350);
+    expect(design.printBedZ).toBe(300);
+  });
+
+  it('uses preset defaults when no custom prefs are saved', () => {
+    // No saved prefs
+    clearPrintBedPrefs();
+
+    useDesignStore.getState().loadPreset('Aerobatic');
+    const { design } = useDesignStore.getState();
+
+    // Should use the preset's (factory) defaults
+    expect(design.printBedX).toBe(BED_DEFAULTS.printBedX);
+    expect(design.printBedY).toBe(BED_DEFAULTS.printBedY);
+    expect(design.printBedZ).toBe(BED_DEFAULTS.printBedZ);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// newDesign + bed prefs
+// ---------------------------------------------------------------------------
+
+describe('designStore.newDesign with saved bed prefs', () => {
+  it('applies saved bed prefs to new designs', () => {
+    savePrintBedPrefs({ printBedX: 400, printBedY: 400, printBedZ: 450 });
+
+    useDesignStore.getState().newDesign();
+    const { design } = useDesignStore.getState();
+
+    expect(design.printBedX).toBe(400);
+    expect(design.printBedY).toBe(400);
+    expect(design.printBedZ).toBe(450);
+  });
+
+  it('uses factory defaults for new designs when no prefs are saved', () => {
+    clearPrintBedPrefs();
+
+    useDesignStore.getState().newDesign();
+    const { design } = useDesignStore.getState();
+
+    expect(design.printBedX).toBe(BED_DEFAULTS.printBedX);
+    expect(design.printBedY).toBe(BED_DEFAULTS.printBedY);
+    expect(design.printBedZ).toBe(BED_DEFAULTS.printBedZ);
+  });
+});


### PR DESCRIPTION
## Summary

Implements GitHub issue #155 — allow users to configure and persist their printer's print bed dimensions across sessions, so they are not reset when loading different presets or starting a new design.

- Bed preferences are stored in `localStorage` (machine-local, not per-design) under the key `cheng-print-bed-prefs`
- Default dimensions (220 x 220 x 250 mm) match the PRINT_DEFAULTS for Ender-3/Prusa-class printers
- Preferences are validated and clamped on load (100-500 mm X/Y, 50-500 mm Z)
- Applying saved preferences does **not** set `isDirty` — it is a transparent preference restore

## Related Issue

Closes #155

## Changes

- **New `frontend/src/lib/printBedPrefs.ts`** — `loadPrintBedPrefs`, `savePrintBedPrefs`, `clearPrintBedPrefs`, `isDefaultPrintBedPrefs`, `BED_DEFAULTS`, `BED_CONSTRAINTS`; never throws (localStorage errors silently swallowed)
- **New `frontend/src/hooks/usePrintBedPreferences.ts`** — React hook called at App root; applies saved prefs on mount; returns `saveAsDefault` and `resetToDefaults` helpers
- **`designStore.ts`** — Added `applyBedPreferences()` action (bypasses `isDirty`); `loadPreset()` and `newDesign()` now re-apply saved prefs after loading
- **`ExportDialog.tsx`** — New "Save as default" and "Reset to defaults" buttons in the Print Bed section with 2500 ms "Saved!" flash feedback; optional callback props; timer cleanup on unmount/close
- **`App.tsx`** — Wires `usePrintBedPreferences` hook and passes callbacks to ExportDialog
- **24 new tests** — 17 unit tests (`printBedPrefs.test.ts`) + 7 integration tests (`printBedPrefsIntegration.test.ts`); all passing; no regressions

## Gemini Peer Review

Reviewed by Gemini. Approved with no blocking issues. Minor observations noted:
1. The `!isDefaultPrintBedPrefs(prefs)` guard in `loadPreset`/`newDesign` is intentional — avoids overwriting preset-specific bed dims when user has factory defaults.
2. Suggested optional idempotency optimization in `applyBedPreferences` (non-critical, `isDirty` is not affected).
3. Flash timer cleanup pattern confirmed correct.

Cycles used: 1 of 3

## Testing

- 17 unit tests cover `loadPrintBedPrefs` (defaults, valid values, out-of-range clamping, malformed JSON, storage exceptions), `savePrintBedPrefs` (write, overwrite, storage exceptions), `clearPrintBedPrefs`, `isDefaultPrintBedPrefs`, and round-trip
- 7 integration tests cover `designStore.applyBedPreferences` (no-op for defaults, applies custom prefs, does not set `isDirty`), `loadPreset` with saved prefs, and `newDesign` with saved prefs
- All 190+ existing frontend Vitest tests continue to pass (no regressions)