### PR TITLE
[FE] Create CgVsNpGauge component

### DIFF
--- a/frontend/src/components/stability/CgVsNpGauge.tsx
+++ b/frontend/src/components/stability/CgVsNpGauge.tsx
@@ -80,23 +80,23 @@ export function CgVsNpGauge({
           aria-hidden="true"
         />
 
-        {/* CG indicator — filled pill */}
+        {/* CG indicator — filled pill, centered via Tailwind transform */}
         <div
-          className={`absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full ${cgColor} border-2 border-zinc-900`}
-          style={{ left: `${cgBarPct}%`, transform: 'translate(-50%, -50%)' }}
+          className={`absolute top-1/2 w-3 h-3 -translate-x-1/2 -translate-y-1/2 rounded-full ${cgColor} border-2 border-zinc-900`}
+          style={{ left: `${cgBarPct}%` }}
           aria-hidden="true"
         />
 
         {/* NP indicator — open circle with blue stroke */}
         <div
-          className="absolute top-1/2 -translate-y-1/2 w-3 h-3 rounded-full border-2 border-blue-400 bg-transparent"
-          style={{ left: `${npBarPct}%`, transform: 'translate(-50%, -50%)' }}
+          className="absolute top-1/2 w-3 h-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-blue-400 bg-transparent"
+          style={{ left: `${npBarPct}%` }}
           aria-hidden="true"
         />
       </div>
 
-      {/* Tick labels */}
-      <div className="flex justify-between text-xs text-zinc-500 mt-0.5 px-0">
+      {/* Tick labels — aria-hidden since bar has descriptive aria-label */}
+      <div className="flex justify-between text-xs text-zinc-500 mt-0.5 px-0" aria-hidden="true">
         <span>0%</span>
         <span>10%</span>
         <span>20%</span>


### PR DESCRIPTION
## Summary

Creates `frontend/src/components/stability/CgVsNpGauge.tsx` — a horizontal bar gauge (0–40% MAC) showing the CG and Neutral Point positions relative to the Mean Aerodynamic Chord with a highlighted safe zone band.

## Related Issue
Closes #312

## Changes
- New file: `frontend/src/components/stability/CgVsNpGauge.tsx`
- Horizontal bar with safe zone (20–30% MAC = 50–75% of bar) in `bg-green-500/20`
- CG indicator: `bg-green-500` when stable, `bg-red-500` when negative margin
- NP indicator: open blue circle
- Three value rows below bar (CG %, NP %, margin with category)
- `role="img"` with descriptive `aria-label`, `title` tooltip
- Tick labels hidden from screen readers (`aria-hidden="true"`)
- Indicators use Tailwind `-translate-x-1/2 -translate-y-1/2` without inline transform conflict

## Gemini Peer Review
Issues raised: (1) CSS transform conflict — fixed by removing inline `transform` from `style`, using only Tailwind translate utilities; (2) Tick labels accessibility — fixed with `aria-hidden="true"`.
Cycles used: 1 of 3

## Testing
- `pnpm build` passes with 0 TypeScript errors