### PR TITLE
[FE] Create StaticMarginGauge component

### DIFF
--- a/frontend/src/components/stability/StaticMarginGauge.tsx
+++ b/frontend/src/components/stability/StaticMarginGauge.tsx
@@ -114,7 +114,7 @@ export function StaticMarginGauge({
             className="absolute text-[10px] text-zinc-500 -translate-x-1/2"
             style={{ left: `${valueToBarPct(tick)}%` }}
           >
-            {tick >= 0 ? `${tick}%` : `${tick}%`}
+            {tick}%
           </span>
         ))}
       </div>


### PR DESCRIPTION
## Summary

Creates `frontend/src/components/stability/StaticMarginGauge.tsx` — a segmented horizontal bar showing static margin against four color-coded stability zones.

## Related Issue
Closes #313

## Changes
- New file: `frontend/src/components/stability/StaticMarginGauge.tsx`
- 4 color zones: red (-5–0%), yellow (0–2%), green (2–15%), blue (15–25%)
- Zone labels above bar, tick labels below at zone boundaries
- Thumb indicator at current margin position, color matching current zone
- Delegates all classification to `getStabilityStatus()` / `getMarginColorClass()` — no duplicated threshold logic
- `role="progressbar"` with `aria-valuemin=-5`, `aria-valuenow`, `aria-valuemax=25`, `aria-label`

## Gemini Peer Review
Issues raised: redundant ternary in tick labels — fixed (`{tick}%` directly). Approved with minor suggestion.
Cycles used: 1 of 3

## Testing
- `pnpm build` passes with 0 TypeScript errors