### PR TITLE
[FE] Create StabilityPanel container component

### DIFF
--- a/frontend/src/components/panels/StabilityPanel.tsx
+++ b/frontend/src/components/panels/StabilityPanel.tsx
@@ -69,7 +69,7 @@ export function StabilityPanel(): React.JSX.Element {
               />
               <DerivedField
                 label="Static Margin"
-                value={derived.neutralPointMm - derived.estimatedCgMm}
+                value={(derived.neutralPointMm ?? 0) - (derived.estimatedCgMm ?? 0)}
                 unit="mm"
                 title="Distance between CG and neutral point (positive = stable). Equivalent to static margin in mm."
               />


### PR DESCRIPTION
## Summary

Creates `frontend/src/components/panels/StabilityPanel.tsx` — the read-only Stability tab panel that composes the three gauge sub-components and an expandable raw values section.

## Related Issue
Closes #316

## Changes
- New file: `frontend/src/components/panels/StabilityPanel.tsx`
- Reads `derived` from Zustand store via `useDesignStore((s) => s.derived)`
- Renders loading placeholder when `derived` is null
- Composes: `CgVsNpGauge`, `StaticMarginGauge`, `PitchStabilityIndicator`
- Expandable `<details>` section with 6 `DerivedField` rows (CG, NP, SM, Vh, loading, MAC)
- Static margin mm calculation guards against NaN with nullish coalescing
- `<section role="region" aria-label="Static Stability Analysis">` for accessibility

## Gemini Peer Review
Issues raised: NaN guard for neutralPointMm - estimatedCgMm calculation — addressed with `?? 0` fallbacks.
Cycles used: 1 of 3

## Testing
- `pnpm build` passes with 0 TypeScript errors