### PR TITLE
[FE] Stability plots as floating overlay panel with Toggle Plots toolbar button

### DIFF
--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -796,6 +796,7 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
           ref={togglePlotsButtonRef}
           onClick={() => setPlotsOpen((v) => !v)}
           aria-pressed={plotsOpen}
+          aria-controls="stability-overlay"
           aria-label={plotsOpen ? 'Hide stability plots' : 'Show stability plots'}
           className={`px-3 py-1 text-xs rounded focus:outline-none focus:ring-1 focus:ring-zinc-600
             ${plotsOpen


### PR DESCRIPTION
## Summary

Adds a floating overlay panel for stability plots, toggled via a new "Toggle Plots" button in the main toolbar. The overlay sits above the 3D viewport at top-right so users can watch stability metrics update live while adjusting parameters in other panels.

## Related Issue
Closes #317

## Changes
- New file: `frontend/src/components/StabilityOverlay.tsx`
  - Fixed-position floating card (`top-14 right-4 z-40 w-72`)
  - Non-modal dialog (`role="dialog" aria-modal="false"`)
  - Header with title + close button (aria-label, focus on mount)
  - Scrollable body wrapping `<StabilityPanel />`
  - Escape key closes overlay (useEffect with cleanup)
  - Focus restored to toolbar toggle button on close

- Modified: `frontend/src/components/Toolbar.tsx`
  - Import `StabilityOverlay`
  - Add `plotsOpen` state + `togglePlotsButtonRef`
  - Add "Toggle Plots" button: `aria-pressed`, `aria-controls="stability-overlay"`, blue when active
  - Conditionally render `<StabilityOverlay>` below History Panel

- `ComponentPanel.tsx` NOT modified (no Stability tab added per updated spec)

## Gemini Peer Review
Issues raised: (1) Escape key support — added with useEffect cleanup; (2) aria-controls linkage — added id + aria-controls; (3) handleClose ordering — fixed with useCallback.
Cycles used: 1 of 3

## Testing
- `pnpm build` passes with 0 TypeScript errors