### PR TITLE
[BE] Extend DerivedValues model with 7 stability fields

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -245,6 +245,18 @@ class DerivedValues(CamelModel):
     weight_fuselage_g: float = 0.0
     weight_total_g: float = 0.0
 
+    # Static stability fields (v1.1) — computed by backend/stability.py,
+    # serialized to frontend as camelCase via alias_generator=to_camel.
+    # All default to 0.0 for backward compatibility; neutral_point_pct_mac
+    # defaults to 25.0 (wing AC) to avoid a misleading zero NP in edge cases.
+    neutral_point_mm: float = 0.0
+    neutral_point_pct_mac: float = 25.0
+    cg_pct_mac: float = 0.0
+    static_margin_pct: float = 0.0
+    tail_volume_h: float = 0.0
+    tail_volume_v: float = 0.0
+    wing_loading_g_dm2: float = 0.0
+
 
 # ---------------------------------------------------------------------------
 # Validation Warning


### PR DESCRIPTION
## Summary

Adds 7 static stability fields to the `DerivedValues(CamelModel)` in `backend/models.py`. No WebSocket changes needed — fields are automatically serialized via `model_dump(by_alias=True)`.

## Related Issue
Closes #309

## Changes
- Added to `DerivedValues`: `neutral_point_mm`, `neutral_point_pct_mac`, `cg_pct_mac`, `static_margin_pct`, `tail_volume_h`, `tail_volume_v`, `wing_loading_g_dm2`
- All default to `0.0` for backward compatibility
- `neutral_point_pct_mac` defaults to `25.0` (wing AC) to avoid misleading zero NP
- camelCase aliases auto-generated: `neutralPointMm`, `neutralPointPctMac`, `cgPctMac`, `staticMarginPct`, `tailVolumeH`, `tailVolumeV`, `wingLoadingGDm2`

## Gemini Peer Review
Cycle 1: APPROVED with no issues. Noted sensible defaults and unit naming consistency.

## Testing
- `model_dump(by_alias=True)` verified to include all 7 camelCase keys
- `python -m pytest tests/backend/ -v` — 765 passed, no regressions