### PR TITLE
Add @pytest.mark.smoke to backend smoke tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ select = ["E", "F", "I", "UP"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "smoke: fast, critical-path tests that always run pre-commit (< 15s total)",
+    "integration: tests that require the full engine/app to be running",
+]

--- a/tests/backend/test_cheng_mode.py
+++ b/tests/backend/test_cheng_mode.py
@@ -130,15 +130,18 @@ class TestMemoryStorageIsolation:
 
 
 class TestGetChengMode:
+    @pytest.mark.smoke
     def test_default_is_local(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without CHENG_MODE set the default is 'local'."""
         monkeypatch.delenv("CHENG_MODE", raising=False)
         assert get_cheng_mode() == "local"
 
+    @pytest.mark.smoke
     def test_local_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CHENG_MODE", "local")
         assert get_cheng_mode() == "local"
 
+    @pytest.mark.smoke
     def test_cloud_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CHENG_MODE", "cloud")
         assert get_cheng_mode() == "cloud"
@@ -167,6 +170,7 @@ class TestGetChengMode:
 
 
 class TestCreateStorageBackend:
+    @pytest.mark.smoke
     def test_local_mode_returns_local_storage(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path
     ) -> None:
@@ -178,6 +182,7 @@ class TestCreateStorageBackend:
         backend = create_storage_backend()
         assert isinstance(backend, LocalStorage)
 
+    @pytest.mark.smoke
     def test_cloud_mode_returns_memory_storage(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -210,6 +215,7 @@ class TestInfoEndpoint:
 
         return TestClient(app)
 
+    @pytest.mark.smoke
     def test_info_local_mode(
         self, client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -234,6 +240,7 @@ class TestInfoEndpoint:
         assert data["mode"] == "cloud"
         assert "MemoryStorage" in data["storage"]
 
+    @pytest.mark.smoke
     def test_info_returns_version(self, client: TestClient) -> None:
         """GET /api/info always includes a version field."""
         resp = client.get("/api/info")

--- a/tests/backend/test_cloud_run.py
+++ b/tests/backend/test_cloud_run.py
@@ -25,6 +25,7 @@ def reset_module():
 class TestHealthEndpoint:
     """Health endpoint returns required fields for Cloud Run readiness probes."""
 
+    @pytest.mark.smoke
     @pytest.mark.asyncio
     async def test_health_returns_status_ok(self):
         from backend.main import app
@@ -34,6 +35,7 @@ class TestHealthEndpoint:
         data = r.json()
         assert data["status"] == "ok"
 
+    @pytest.mark.smoke
     @pytest.mark.asyncio
     async def test_health_returns_mode_field(self):
         """Cloud Run startup/liveness probes rely on /health; mode field aids debugging."""
@@ -45,6 +47,7 @@ class TestHealthEndpoint:
         assert "mode" in data
         assert data["mode"] in ("local", "cloud")
 
+    @pytest.mark.smoke
     @pytest.mark.asyncio
     async def test_health_returns_version(self):
         from backend.main import app

--- a/tests/backend/test_memory_storage.py
+++ b/tests/backend/test_memory_storage.py
@@ -25,6 +25,7 @@ def mem() -> MemoryStorage:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.smoke
 def test_save_and_load_roundtrip(mem: MemoryStorage) -> None:
     """Data saved then loaded must be identical."""
     data = {"id": "d1", "name": "Test", "wing_span": 1000}
@@ -33,6 +34,7 @@ def test_save_and_load_roundtrip(mem: MemoryStorage) -> None:
     assert loaded == data
 
 
+@pytest.mark.smoke
 def test_save_overwrites_existing(mem: MemoryStorage) -> None:
     """Saving with an existing id must replace the previous data."""
     mem.save_design("d1", {"id": "d1", "name": "Original"})
@@ -41,6 +43,7 @@ def test_save_overwrites_existing(mem: MemoryStorage) -> None:
     assert loaded["name"] == "Updated"
 
 
+@pytest.mark.smoke
 def test_load_not_found_raises(mem: MemoryStorage) -> None:
     """load_design must raise FileNotFoundError for unknown ids."""
     with pytest.raises(FileNotFoundError, match="Design not found: missing"):

--- a/tests/backend/test_models.py
+++ b/tests/backend/test_models.py
@@ -18,6 +18,7 @@ from backend.models import (
 class TestAircraftDesign:
     """Tests for the AircraftDesign model."""
 
+    @pytest.mark.smoke
     def test_defaults(self) -> None:
         """Default construction should produce a valid model."""
         d = AircraftDesign()
@@ -27,6 +28,7 @@ class TestAircraftDesign:
         assert d.fuselage_preset == "Conventional"
         assert d.tail_type == "Conventional"
 
+    @pytest.mark.smoke
     def test_custom_values(self) -> None:
         """Construction with custom values should preserve them."""
         d = AircraftDesign(
@@ -88,6 +90,7 @@ class TestAircraftDesign:
         with pytest.raises(ValidationError):
             AircraftDesign(wing_tip_root_ratio=1.5)
 
+    @pytest.mark.smoke
     def test_literal_fuselage_preset(self) -> None:
         """Invalid fuselage preset should fail validation."""
         with pytest.raises(ValidationError):
@@ -187,6 +190,7 @@ class TestAircraftDesign:
         # Sections always sum to fuselage_length
         assert abs(nose_len + cabin_len + tail_len - d.fuselage_length) < 1e-9
 
+    @pytest.mark.smoke
     def test_serialization_round_trip(self) -> None:
         """Serialize to dict and back should produce identical model."""
         original = AircraftDesign(id="round-trip", wing_span=1500)

--- a/tests/backend/test_stability.py
+++ b/tests/backend/test_stability.py
@@ -49,6 +49,7 @@ _NEEDS_ENGINE = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.smoke
 def test_neutral_point_formula() -> None:
     """NP_pct = (0.25 + 0.88 * V_h) * 100."""
     v_h = 0.5
@@ -57,6 +58,7 @@ def test_neutral_point_formula() -> None:
     assert abs(np_pct - expected) < 0.001
 
 
+@pytest.mark.smoke
 def test_neutral_point_zero_v_h() -> None:
     """V_h=0 (no tail) => NP = 25% MAC (wing aerodynamic center)."""
     np_pct = _neutral_point_pct_mac(0.0)
@@ -68,6 +70,7 @@ def test_neutral_point_zero_v_h() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.smoke
 def test_static_margin_positive() -> None:
     """SM > 0 when CG is ahead of NP (pitch-stable)."""
     cg_pct = 25.0   # 25% MAC

--- a/tests/backend/test_validation.py
+++ b/tests/backend/test_validation.py
@@ -343,6 +343,7 @@ class TestV08:
 
 
 class TestDefaultDesign:
+    @pytest.mark.smoke
     def test_default_has_few_warnings(self) -> None:
         """Default design parameters should produce a flyable, printable design."""
         design = AircraftDesign()


### PR DESCRIPTION
## Summary
Adds smoke test marker to pyproject.toml and marks 21 critical-path backend tests with @pytest.mark.smoke.

## Related Issue
Closes #339

## Changes
- Added 'smoke' marker registration to pyproject.toml [tool.pytest.ini_options]
- Added also 'integration' marker registration for clarity
- Applied @pytest.mark.smoke to tests in 6 files:
  - test_models.py: 4 tests (defaults, custom_values, literal_fuselage_preset, serialization_round_trip)
  - test_validation.py: 1 test (test_default_has_few_warnings)
  - test_stability.py: 3 tests (neutral_point_formula, neutral_point_zero_v_h, static_margin_positive)
  - test_cheng_mode.py: 7 tests (get_cheng_mode x3, create_storage_backend x2, info endpoint x2)
  - test_memory_storage.py: 3 tests (CRUD: save/load roundtrip, overwrites, not-found)
  - test_cloud_run.py: 3 tests (health endpoint: status_ok, mode_field, version)

## Testing
- pytest -m smoke: 21 tests selected, 1.08s runtime (target: < 15s)
- All modified test files pass (1 pre-existing failure in test_cheng_mode excluded — not introduced by this PR)
- Full suite: 804 passed, 1 pre-existing failure