### PR TITLE
Frontend Overlay Restructure (3-Tab Navigation)

### DIFF
--- a/frontend/src/components/StabilityOverlay.tsx
+++ b/frontend/src/components/StabilityOverlay.tsx
@@ -1,12 +1,18 @@
 // ============================================================================
-// CHENG — Stability Overlay
-// Floating panel wrapper that positions StabilityPanel as a fixed card
-// overlaying the 3D viewport. Toggled from the Toolbar.
-// Issue #317
+// CHENG — Stability Analysis Overlay
+// Floating panel wrapper with three tabs: Static Stability, Mass Properties,
+// Dynamic Stability. Toggled from the Toolbar.
+// Issue #355
 // ============================================================================
 
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { StabilityPanel } from './panels/StabilityPanel';
+import { MassPropertiesTab } from './stability/MassPropertiesTab';
+import { DynamicStabilityTab } from './stability/DynamicStabilityTab';
+
+// ─── Tab type ─────────────────────────────────────────────────────────────────
+
+export type StabilityTab = 'static' | 'mass' | 'dynamic';
 
 // ─── Props ───────────────────────────────────────────────────────────────────
 
@@ -15,17 +21,29 @@ interface StabilityOverlayProps {
   onClose: () => void;
   /** Ref to the toolbar's Toggle Plots button, so focus can be restored on close. */
   toggleButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  /** Initial tab to show when the overlay opens (default: 'static'). */
+  initialTab?: StabilityTab;
+  /** Called when the active tab changes, so parent can track it. */
+  onTabChange?: (tab: StabilityTab) => void;
 }
+
+// ─── Tab definitions ──────────────────────────────────────────────────────────
+
+const TABS: { id: StabilityTab; label: string }[] = [
+  { id: 'static',  label: 'Static' },
+  { id: 'mass',    label: 'Mass' },
+  { id: 'dynamic', label: 'Dynamic' },
+];
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
- * Floating panel overlay for the Stability Plots feature.
+ * Floating panel overlay for the Stability Analysis feature.
  *
  * Positioning: `fixed top-14 right-4` — just below the 40px toolbar with a
  * visible gap. `z-40` sits above the 3D canvas but below modal dialogs (`z-50`).
  *
- * Width: `w-72` (288px) — readable gauges without obscuring the left sidebar.
+ * Width: `w-80` (320px) — readable gauges without obscuring the left sidebar.
  *
  * Scrollable: `max-h-[calc(100vh-8rem)]` prevents overflow below the viewport.
  *
@@ -37,8 +55,11 @@ interface StabilityOverlayProps {
 export function StabilityOverlay({
   onClose,
   toggleButtonRef,
+  initialTab = 'static',
+  onTabChange,
 }: StabilityOverlayProps): React.JSX.Element {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [activeTab, setActiveTab] = useState<StabilityTab>(initialTab);
 
   // Close handler: dismiss overlay and restore focus to the toolbar toggle button.
   const handleClose = useCallback(() => {
@@ -63,25 +84,35 @@ export function StabilityOverlay({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [handleClose]);
 
+  // Sync initialTab if parent changes it after mount (e.g. summary card click).
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  const handleTabChange = (tab: StabilityTab) => {
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
+
   return (
     <div
       id="stability-overlay"
       role="dialog"
-      aria-label="Stability plots"
+      aria-label="Stability analysis"
       aria-modal="false"
-      className="fixed top-14 right-4 z-40 w-72 bg-zinc-900 border border-zinc-700
+      className="fixed top-14 right-4 z-40 w-80 bg-zinc-900 border border-zinc-700
         rounded-lg shadow-2xl shadow-black/60 flex flex-col"
     >
       {/* Header bar */}
       <div className="flex items-center justify-between px-3 py-2
         border-b border-zinc-800 flex-shrink-0">
         <span className="text-xs font-semibold text-zinc-300">
-          Stability Plots
+          Stability Analysis
         </span>
         <button
           ref={closeButtonRef}
           onClick={handleClose}
-          aria-label="Close stability plots"
+          aria-label="Close stability analysis"
           className="w-5 h-5 flex items-center justify-center text-zinc-500
             rounded hover:bg-zinc-700 hover:text-zinc-200
             focus:outline-none focus:ring-1 focus:ring-zinc-600 text-sm leading-none"
@@ -91,9 +122,43 @@ export function StabilityOverlay({
         </button>
       </div>
 
+      {/* Tab bar */}
+      <div
+        role="tablist"
+        aria-label="Stability analysis tabs"
+        className="flex border-b border-zinc-800 flex-shrink-0"
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`stability-tab-panel-${tab.id}`}
+            id={`stability-tab-${tab.id}`}
+            onClick={() => handleTabChange(tab.id)}
+            className={[
+              'flex-1 px-2 py-1.5 text-xs font-medium transition-colors',
+              'focus:outline-none focus:ring-1 focus:ring-inset focus:ring-zinc-600',
+              activeTab === tab.id
+                ? 'text-sky-400 border-b-2 border-sky-500 bg-zinc-800/50'
+                : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/30',
+            ].join(' ')}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
       {/* Panel body — scrollable if content overflows viewport */}
-      <div className="overflow-y-auto flex-1 min-h-0 max-h-[calc(100vh-8rem)]">
-        <StabilityPanel />
+      <div
+        id={`stability-tab-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`stability-tab-${activeTab}`}
+        className="overflow-y-auto flex-1 min-h-0 max-h-[calc(100vh-9rem)]"
+      >
+        {activeTab === 'static'  && <StabilityPanel />}
+        {activeTab === 'mass'    && <MassPropertiesTab />}
+        {activeTab === 'dynamic' && <DynamicStabilityTab />}
       </div>
     </div>
   );

--- a/frontend/src/components/stability/DynamicStabilityTab.tsx
+++ b/frontend/src/components/stability/DynamicStabilityTab.tsx
@@ -1,0 +1,20 @@
+// ============================================================================
+// CHENG — Dynamic Stability Tab (stub)
+// Placeholder for the Dynamic Stability tab in the Stability Analysis overlay.
+// Full implementation will follow in a separate issue.
+// Issue #355
+// ============================================================================
+
+import React from 'react';
+
+/**
+ * Dynamic Stability Tab — stub placeholder.
+ * Full implementation in issue #358.
+ */
+export function DynamicStabilityTab(): React.JSX.Element {
+  return (
+    <div className="p-4 text-xs text-zinc-400">
+      Dynamic Stability coming soon
+    </div>
+  );
+}

--- a/frontend/src/components/stability/MassPropertiesTab.tsx
+++ b/frontend/src/components/stability/MassPropertiesTab.tsx
@@ -1,0 +1,20 @@
+// ============================================================================
+// CHENG — Mass Properties Tab (stub)
+// Placeholder for the Mass Properties tab in the Stability Analysis overlay.
+// Full implementation will follow in a separate issue.
+// Issue #355
+// ============================================================================
+
+import React from 'react';
+
+/**
+ * Mass Properties Tab — stub placeholder.
+ * Full implementation in issue #357.
+ */
+export function MassPropertiesTab(): React.JSX.Element {
+  return (
+    <div className="p-4 text-xs text-zinc-400">
+      Mass Properties coming soon
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Converts `StabilityOverlay.tsx` from a single-content panel to a tabbed overlay with three tabs: Static Stability, Mass Properties, Dynamic Stability. Creates stub components for the new tabs.

## Related Issue
Closes #355

## Changes
- `StabilityOverlay.tsx`: Added `useState<StabilityTab>` for active tab, 3-button tab bar with proper ARIA roles, conditional content rendering, `initialTab` and `onTabChange` props, header renamed to "Stability Analysis", width increased from `w-72` to `w-80`
- `stability/MassPropertiesTab.tsx`: Stub placeholder component
- `stability/DynamicStabilityTab.tsx`: Stub placeholder component

## Testing
- TypeScript compiles without errors
- Escape key closes overlay (unchanged behavior)
- Focus management on open/close unchanged