### PR TITLE
Mass Properties Module (backend/mass_properties.py)

### DIFF
--- a/backend/mass_properties.py
+++ b/backend/mass_properties.py
@@ -246,7 +246,12 @@ def resolve_mass_properties(
     if design.cg_override_x_mm is not None:
         cg_x_mm = float(design.cg_override_x_mm)
     else:
-        cg_x_mm = _get(derived, "estimated_cg_mm")
+        # NOTE: derived["estimated_cg_mm"] is wing-LE-referenced (distance aft of
+        # wing root LE), not nose-referenced.  MassProperties.cg_x_mm is defined
+        # as nose-referenced.  We cannot convert without knowing wing_x here, so
+        # use 30% of fuselage length from nose — consistent with the conventional
+        # RC "balance at 25-30% MAC" rule and the engine's own fallback.
+        cg_x_mm = design.fuselage_length * 0.30
 
     if design.cg_override_z_mm is not None:
         cg_z_mm = float(design.cg_override_z_mm)


### PR DESCRIPTION
## Summary
Creates `backend/mass_properties.py` with the `MassProperties` dataclass, `estimate_inertia()` component build-up method, and `resolve_mass_properties()` entry point.

## Related Issue
Closes #351

## Changes
- New `backend/mass_properties.py`:
  - `MassProperties` dataclass: mass_g, cg_x/y/z_mm, ixx/iyy/izz_kg_m2, estimated flags
  - `estimate_inertia(design, derived)`: wing (thin rod), fuselage (cylinder), tail (point mass at l_t), motor/battery contributions. Returns (Ixx, Iyy, Izz) in kg·m²
  - `resolve_mass_properties(design, derived)`: applies MP01-MP07 overrides, falls back to estimates per field. Accepts both dict and DerivedValues.

## Testing
- Ixx < Iyy for all 6 design archetypes (Trainer/Sport/Aerobatic/Glider/FlyingWing/Scale)
- Override values returned exactly when set
- `ixx_estimated=False` when override present, `True` when estimated