### PR TITLE
Add full test suite as required CI check on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "plan/**"
+
+jobs:
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run backend tests
+        run: uv run python -m pytest tests/backend/ -v --tb=short
+
+  frontend-tests:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Run frontend tests
+        working-directory: frontend
+        run: pnpm exec vitest run --config ../tests/frontend/vitest.config.ts


### PR DESCRIPTION
## Summary

Creates `.github/workflows/ci.yml` with two jobs (`backend-tests` and
`frontend-tests`) that run on all pull requests targeting `main` and `plan/**`
branches, enforcing Tier 3 (full suite) test coverage at the merge gate.

## Related Issue

Closes #345

## Changes

- Created `.github/workflows/ci.yml`
- `backend-tests` job: uses `uv` + Python 3.11, installs deps via `uv sync --extra dev`, runs `pytest tests/backend/ -v`
- `frontend-tests` job: uses `pnpm` + Node.js 20, installs frontend deps, runs `vitest run` with the full test config
- Triggers on `pull_request` to `main` and `plan/**` branches
- Playwright E2E excluded (requires live app — manual pre-merge only)

## Testing

YAML file validated by inspection. Both job names (`Backend Tests` and
`Frontend Tests`) will appear as required checks in GitHub PR status.
Pre-commit tests: smoke only (no backend/frontend source changes detected).