### PR TITLE
feat(engine): wire DATCOM dynamic stability into derived values (#353)

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -287,6 +287,76 @@ class AircraftDesign(CamelModel):
 
 
 # ---------------------------------------------------------------------------
+# Dynamic Stability Result — computed by DATCOM pipeline, read-only
+# ---------------------------------------------------------------------------
+
+class DynamicStabilityResult(CamelModel):
+    """DATCOM-computed dynamic stability mode characteristics.
+
+    Serialized to frontend as camelCase via alias_generator=to_camel.
+    All frequencies in rad/s; periods and time constants in seconds.
+    """
+
+    # Longitudinal modes
+    sp_omega_n: float = 0.0
+    """Short-period natural frequency (rad/s)."""
+
+    sp_zeta: float = 0.0
+    """Short-period damping ratio."""
+
+    sp_period_s: float = 0.0
+    """Short-period period (s)."""
+
+    phugoid_omega_n: float = 0.0
+    """Phugoid natural frequency (rad/s)."""
+
+    phugoid_zeta: float = 0.0
+    """Phugoid damping ratio."""
+
+    phugoid_period_s: float = 0.0
+    """Phugoid period (s)."""
+
+    # Lateral/directional modes
+    dr_omega_n: float = 0.0
+    """Dutch roll natural frequency (rad/s)."""
+
+    dr_zeta: float = 0.0
+    """Dutch roll damping ratio."""
+
+    dr_period_s: float = 0.0
+    """Dutch roll period (s)."""
+
+    roll_tau_s: float = 0.0
+    """Roll mode time constant (s)."""
+
+    spiral_tau_s: float = 0.0
+    """Spiral mode time constant (s). Negative = divergent."""
+
+    spiral_t2_s: float = 0.0
+    """Spiral time-to-double (s). Large positive = effectively stable."""
+
+    # Stability derivatives (passthrough for frontend display)
+    cl_alpha: float = 0.0
+    cd_alpha: float = 0.0
+    cm_alpha: float = 0.0
+    cl_q: float = 0.0
+    cm_q: float = 0.0
+    cl_alphadot: float = 0.0
+    cm_alphadot: float = 0.0
+    cy_beta: float = 0.0
+    cl_beta: float = 0.0
+    cn_beta: float = 0.0
+    cy_p: float = 0.0
+    cl_p: float = 0.0
+    cn_p: float = 0.0
+    cy_r: float = 0.0
+    cl_r: float = 0.0
+    cn_r: float = 0.0
+
+    derivatives_estimated: bool = True
+
+
+# ---------------------------------------------------------------------------
 # Derived Values — computed by geometry engine, read-only
 # ---------------------------------------------------------------------------
 
@@ -317,6 +387,10 @@ class DerivedValues(CamelModel):
     tail_volume_h: float = 0.0
     tail_volume_v: float = 0.0
     wing_loading_g_dm2: float = 0.0
+
+    # Dynamic stability fields (v1.2) — computed by DATCOM pipeline.
+    # None when DATCOM computation is unavailable or fails.
+    dynamic_stability: Optional[DynamicStabilityResult] = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/test_derived_values.py
+++ b/tests/backend/test_derived_values.py
@@ -253,7 +253,7 @@ class TestDerivedEdgeCases:
         assert d["wall_thickness_mm"] == pytest.approx(1.5)
 
     def test_all_derived_keys_present(self):
-        """All 19 derived keys should be in the result (12 base + 7 stability v1.1)."""
+        """All 20 derived keys should be in the result (12 base + 7 stability v1.1 + 1 dynamic v1.2)."""
         d = compute_derived_values(_trainer())
         expected_keys = {
             # Base derived values (12)
@@ -277,5 +277,7 @@ class TestDerivedEdgeCases:
             "tail_volume_h",
             "tail_volume_v",
             "wing_loading_g_dm2",
+            # Dynamic stability field (v1.2, 1 field — nested DynamicStabilityResult or None)
+            "dynamic_stability",
         }
         assert set(d.keys()) == expected_keys


### PR DESCRIPTION
## Summary

- Adds `DynamicStabilityResult` Pydantic model (CamelModel) to `backend/models.py` with all 12 mode parameters (sp_omega_n, sp_zeta, phugoid_omega_n, phugoid_zeta, dr_omega_n, dr_zeta, roll_tau_s, spiral_tau_s, spiral_t2_s), 16 stability derivatives, and `derivatives_estimated` flag
- Adds `dynamic_stability: Optional[DynamicStabilityResult] = None` field to `DerivedValues` — serializes to `dynamicStability` in WebSocket JSON trailer via camelCase alias_generator
- Wires the DATCOM pipeline into `compute_derived_values()` in `engine.py`: `resolve_mass_properties` → `compute_flight_condition` → `compute_stability_derivatives` → `compute_dynamic_modes`; result stored as `DynamicStabilityResult` in the derived dict
- Entire DATCOM block wrapped in `try/except Exception` — failure logs a RuntimeWarning and sets `dynamic_stability = None`, never breaking the main preview path
- Updates `test_derived_values.py` and `test_geometry.py` to reflect 20-key result dict and non-float `dynamic_stability` field

## Test plan

- [x] Full backend test suite: 804 passed, 1 pre-existing failure (unrelated `test_cheng_mode.py`)
- [x] `dynamic_stability` field correctly populated for Trainer preset (SP omega=25 rad/s, phugoid omega=0.27 rad/s)
- [x] `model_dump(by_alias=True)` serializes nested `DynamicStabilityResult` with camelCase keys
- [x] `dynamic_stability = None` path works when DATCOM is unavailable

Closes #353

Part of milestone: dynamic-stability-datcom

🤖 Generated with [Claude Code](https://claude.com/claude-code)