### PR TITLE
feat(ui): add DynamicStabilitySummaryCard in-viewport shortcut (#359)

### DIFF
--- a/frontend/src/components/DynamicStabilitySummaryCard.tsx
+++ b/frontend/src/components/DynamicStabilitySummaryCard.tsx
@@ -1,0 +1,154 @@
+// ============================================================================
+// CHENG — Dynamic Stability Summary Card
+// Compact in-viewport card showing at-a-glance quality dots for 3 key modes.
+// Fixed bottom-left of viewport. Clicking opens the Stability Overlay on the
+// Dynamic Stability tab. Hidden when overlay is open or dynamicStability is null.
+// Issue #359
+// ============================================================================
+
+import React from 'react';
+import { useDesignStore } from '../store/designStore';
+import {
+  classifyShortPeriod,
+  classifyPhugoid,
+  classifyDutchRoll,
+  type ModeQuality,
+} from '../lib/dynamicStabilityAnalyzer';
+
+// ---------------------------------------------------------------------------
+// Quality dot — colored circle
+// ---------------------------------------------------------------------------
+
+interface QualityDotProps {
+  quality: ModeQuality;
+}
+
+function QualityDot({ quality }: QualityDotProps): React.JSX.Element {
+  const colorMap: Record<ModeQuality, string> = {
+    good:       'bg-green-400',
+    acceptable: 'bg-amber-400',
+    poor:       'bg-red-400',
+    unknown:    'bg-zinc-500',
+  };
+  return (
+    <span
+      className={`w-2 h-2 rounded-full shrink-0 ${colorMap[quality]}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface DynamicStabilitySummaryCardProps {
+  /** Whether the stability overlay is currently open (card hides itself). */
+  overlayOpen: boolean;
+  /** Called when the user clicks the card — parent should open overlay. */
+  onOpen: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact summary card displayed at the bottom-left of the 3D viewport.
+ *
+ * Shows three rows: Short-Period, Phugoid, Dutch Roll — each with a
+ * colored quality dot (green/amber/red) derived from the DATCOM results.
+ *
+ * Hidden when:
+ * - dynamicStability is null/undefined (no DATCOM results yet)
+ * - The stability overlay is open (avoids visual redundancy)
+ *
+ * Clicking the card triggers onOpen() which should open the stability overlay
+ * and switch to the Dynamic Stability tab.
+ */
+export function DynamicStabilitySummaryCard({
+  overlayOpen,
+  onOpen,
+}: DynamicStabilitySummaryCardProps): React.JSX.Element | null {
+  const derived = useDesignStore((s) => s.derived);
+  const ds = derived?.dynamicStability;
+
+  // Hide when no data or overlay already open
+  if (!ds || overlayOpen) {
+    return null;
+  }
+
+  const spQuality  = classifyShortPeriod(ds.spZeta, ds.spOmegaN);
+  const phQuality  = classifyPhugoid(ds.phugoidZeta);
+  const drQuality  = classifyDutchRoll(ds.drZeta, ds.drOmegaN);
+
+  // Overall quality: worst of the three
+  const qualityRank: Record<ModeQuality, number> = { good: 0, acceptable: 1, poor: 2, unknown: 3 };
+  const overallRank = Math.max(qualityRank[spQuality], qualityRank[phQuality], qualityRank[drQuality]);
+  const overallLabels = ['Good', 'Acceptable', 'Poor', 'Unknown'];
+  const overallLabel = overallLabels[overallRank] ?? 'Unknown';
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={`Dynamic stability summary: ${overallLabel}. Click to open stability analysis.`}
+      className={[
+        'fixed bottom-4 left-4 z-40',
+        'bg-zinc-900/95 border border-zinc-700/80 rounded-lg shadow-lg shadow-black/40',
+        'px-3 py-2 text-left',
+        'hover:border-zinc-500 hover:bg-zinc-800/95',
+        'focus:outline-none focus:ring-1 focus:ring-sky-500',
+        'transition-colors cursor-pointer',
+        'select-none',
+      ].join(' ')}
+    >
+      {/* Header */}
+      <div className="text-[9px] font-semibold text-zinc-500 uppercase tracking-wider mb-1.5">
+        Stability
+      </div>
+
+      {/* Mode rows */}
+      <div className="flex flex-col gap-1">
+        <ModeRow label="Short-Period" quality={spQuality} />
+        <ModeRow label="Phugoid"      quality={phQuality} />
+        <ModeRow label="Dutch Roll"   quality={drQuality} />
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mode row helper
+// ---------------------------------------------------------------------------
+
+interface ModeRowProps {
+  label: string;
+  quality: ModeQuality;
+}
+
+function ModeRow({ label, quality }: ModeRowProps): React.JSX.Element {
+  const qualityLabels: Record<ModeQuality, string> = {
+    good:       'Good',
+    acceptable: 'OK',
+    poor:       'Poor',
+    unknown:    '—',
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <QualityDot quality={quality} />
+      <span className="text-[10px] text-zinc-400 flex-1 leading-none">{label}</span>
+      <span
+        className={[
+          'text-[10px] font-medium leading-none',
+          quality === 'good'       ? 'text-green-400' :
+          quality === 'acceptable' ? 'text-amber-400' :
+          quality === 'poor'       ? 'text-red-400'   :
+          'text-zinc-500',
+        ].join(' ')}
+      >
+        {qualityLabels[quality]}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -18,6 +18,8 @@ import { ModeBadge } from './ModeBadge';
 import { useModeInfo } from '../hooks/useModeInfo';
 import { UnitToggle } from './UnitToggle';
 import { StabilityOverlay } from './StabilityOverlay';
+import type { StabilityTab } from './StabilityOverlay';
+import { DynamicStabilitySummaryCard } from './DynamicStabilitySummaryCard';
 import { PRESET_DESCRIPTIONS } from '../lib/presets';
 import {
   listCustomPresets,
@@ -520,6 +522,7 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
   const [loadDialogOpen, setLoadDialogOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [plotsOpen, setPlotsOpen] = useState(false);
+  const [plotsInitialTab, setPlotsInitialTab] = useState<StabilityTab>('static');
   const [isEditingName, setIsEditingName] = useState(false);
   const togglePlotsButtonRef = useRef<HTMLButtonElement>(null);
   const [editNameValue, setEditNameValue] = useState(designName);
@@ -795,7 +798,10 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
         {/* Toggle Plots button (#317) — opens/closes the stability plots overlay */}
         <button
           ref={togglePlotsButtonRef}
-          onClick={() => setPlotsOpen((v) => !v)}
+          onClick={() => {
+            if (!plotsOpen) setPlotsInitialTab('static');
+            setPlotsOpen((v) => !v);
+          }}
           aria-pressed={plotsOpen}
           aria-controls="stability-overlay"
           aria-label={plotsOpen ? 'Hide stability plots' : 'Show stability plots'}
@@ -1025,8 +1031,18 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
         <StabilityOverlay
           onClose={() => setPlotsOpen(false)}
           toggleButtonRef={togglePlotsButtonRef}
+          initialTab={plotsInitialTab}
         />
       )}
+
+      {/* Dynamic Stability Summary Card (#359) — compact in-viewport status */}
+      <DynamicStabilitySummaryCard
+        overlayOpen={plotsOpen}
+        onOpen={() => {
+          setPlotsInitialTab('dynamic');
+          setPlotsOpen(true);
+        }}
+      />
 
       {/* Load Design Dialog (#93) */}
       <LoadDesignDialog open={loadDialogOpen} onOpenChange={setLoadDialogOpen} />


### PR DESCRIPTION
## Summary

- Adds `DynamicStabilitySummaryCard.tsx`: compact fixed bottom-left of viewport card displaying quality dots for Short-Period, Phugoid, and Dutch Roll modes using green/amber/red colors from the mode classifiers
- Card reads `derived.dynamicStability` from Zustand store; hidden when `dynamicStability` is null/undefined or when the stability overlay is already open
- Clicking the card opens `StabilityOverlay` with the Dynamic Stability tab pre-selected
- Updates `Toolbar.tsx` to import the card and `StabilityTab` type, add `plotsInitialTab` state, pass `initialTab` prop to `StabilityOverlay`, and reset to `'static'` when the toolbar toggle button is used

## Implementation approach

Instead of lifting `activeTab` state all the way to `App.tsx`, added `plotsInitialTab: StabilityTab` state to `Toolbar` alongside the existing `plotsOpen` state. The summary card lives inside Toolbar's render tree (next to the StabilityOverlay) and directly calls `setPlotsInitialTab('dynamic'); setPlotsOpen(true)`. The toolbar toggle button resets to `'static'` on open.

## Test plan

- [x] TypeScript compilation passes (tsc -b && vite build: no errors)
- [x] Frontend Vitest: 339 passed, 3 pre-existing failures (designPortability.test.ts — unrelated)
- [x] Card is hidden when `dynamicStability` is null (no backend data yet)
- [x] Card is hidden when overlay is open
- [x] Clicking card opens overlay with Dynamic tab active
- [x] Toolbar toggle button opens overlay with Static tab (default)

Closes #359

Part of milestone: dynamic-stability-datcom

🤖 Generated with [Claude Code](https://claude.com/claude-code)