### PR TITLE
feat(dynamic-stability): DATCOM dynamic stability analysis + mass properties override

### DIFF
--- a/backend/airfoil_data.py
+++ b/backend/airfoil_data.py
@@ -1,0 +1,252 @@
+"""
+backend/airfoil_data.py
+
+Loads and caches pre-computed NeuralFoil section aerodynamic data from
+datcom/*.constants.json files. Implements interpolation on the scattered
+(Re, Mach) points using the k-nearest-neighbor inverse-distance-weighted
+method in (log Re, Mach) space.
+
+Usage:
+    from backend.airfoil_data import interpolate_section_aero
+    result = interpolate_section_aero("NACA-2412", Re=300000, Mach=0.05)
+    # result: {"cl_alpha_per_rad": ..., "cm_ac": ..., "cl_max": ...,
+    #          "cd_min": ..., "cl_at_cd_min": ...}
+"""
+
+import json
+import math
+import pathlib
+
+# --------------------------------------------------------------------------
+# Module-level cache: stem -> full JSON document + processed grid arrays
+# --------------------------------------------------------------------------
+_AIRFOIL_CACHE: dict[str, dict] = {}
+_PROCESSED_CACHE: dict[str, dict] = {}
+
+# --------------------------------------------------------------------------
+# Mapping from CHENG display names and frontend-hyphenated forms to JSON stems
+# --------------------------------------------------------------------------
+AIRFOIL_NAME_MAP: dict[str, str] = {
+    # Flat plate
+    "Flat-Plate": "flat_plate",
+    "Flat Plate": "flat_plate",
+    # NACA 0006
+    "NACA-0006": "naca0006",
+    "NACA 0006": "naca0006",
+    # NACA 0009
+    "NACA-0009": "naca0009",
+    "NACA 0009": "naca0009",
+    # NACA 0012
+    "NACA-0012": "naca0012",
+    "NACA 0012": "naca0012",
+    # NACA 2412
+    "NACA-2412": "naca2412",
+    "NACA 2412": "naca2412",
+    # NACA 4412
+    "NACA-4412": "naca4412",
+    "NACA 4412": "naca4412",
+    # NACA 6412
+    "NACA-6412": "naca6412",
+    "NACA 6412": "naca6412",
+    # Clark Y
+    "Clark-Y": "clark_y",
+    "Clark Y": "clark_y",
+    # Eppler 193
+    "Eppler-193": "eppler193",
+    "Eppler 193": "eppler193",
+    # Eppler 387
+    "Eppler-387": "eppler387",
+    "Eppler 387": "eppler387",
+    # Selig 1223
+    "Selig-1223": "selig1223",
+    "Selig 1223": "selig1223",
+    # AG-25
+    "AG-25": "ag25",
+    "AG 25": "ag25",
+}
+
+# Keys to interpolate from each condition record
+_INTERPOLATED_KEYS = ("cl_alpha_per_rad", "cm_ac", "cl_max", "cd_min", "cl_at_cd_min")
+
+# Path to datcom directory
+_DATCOM_DIR = pathlib.Path(__file__).parent.parent / "datcom"
+
+# Number of nearest neighbors for IDW interpolation
+_K_NEIGHBORS = 4
+
+
+def _stem_for_name(airfoil_name: str) -> str:
+    """Resolve airfoil display/hyphenated name to JSON file stem."""
+    stem = AIRFOIL_NAME_MAP.get(airfoil_name)
+    if stem is None:
+        # Try case-insensitive lookup
+        lower = airfoil_name.lower()
+        for k, v in AIRFOIL_NAME_MAP.items():
+            if k.lower() == lower:
+                return v
+        raise KeyError(
+            f"Unknown airfoil name '{airfoil_name}'. "
+            f"Known names: {sorted(AIRFOIL_NAME_MAP.keys())}"
+        )
+    return stem
+
+
+def load_airfoil_constants(airfoil_name: str) -> dict:
+    """Load and cache the full constants JSON for the named airfoil.
+
+    Args:
+        airfoil_name: CHENG display name or hyphenated frontend name,
+                      e.g. "NACA-2412", "Clark-Y", "Eppler-387".
+
+    Returns:
+        The full parsed JSON document as a dict.
+
+    Raises:
+        KeyError: if airfoil_name is not in AIRFOIL_NAME_MAP.
+        FileNotFoundError: if the JSON file does not exist in datcom/.
+    """
+    stem = _stem_for_name(airfoil_name)
+    if stem not in _AIRFOIL_CACHE:
+        json_path = _DATCOM_DIR / f"{stem}.constants.json"
+        with open(json_path, "r", encoding="utf-8") as fh:
+            _AIRFOIL_CACHE[stem] = json.load(fh)
+    return _AIRFOIL_CACHE[stem]
+
+
+def get_available_airfoils() -> list[str]:
+    """Return list of canonical JSON stems available in datcom/."""
+    return sorted(
+        p.name.replace(".constants.json", "")
+        for p in _DATCOM_DIR.glob("*.constants.json")
+    )
+
+
+def _get_processed(stem: str) -> dict:
+    """Build and cache the processed point arrays for a given stem.
+
+    Returns dict with:
+        log_re_arr: list[float]   — log(Re) for each condition
+        mach_arr: list[float]     — Mach for each condition
+        values: dict[str, list[float]]  — interpolated key values per condition
+        re_range: tuple[float, float]   — (min_re, max_re)
+        mach_range: tuple[float, float] — (min_mach, max_mach)
+        mach_scale: float               — scale factor to normalize mach to log-Re units
+    """
+    if stem in _PROCESSED_CACHE:
+        return _PROCESSED_CACHE[stem]
+
+    doc = _AIRFOIL_CACHE[stem]
+    conditions = doc["conditions"]
+
+    log_re_arr = [math.log(c["Re"]) for c in conditions]
+    mach_arr = [c["Mach"] for c in conditions]
+
+    # Compute scale factor: normalize Mach range to log-Re range so both axes
+    # contribute equally to the distance metric.
+    min_log_re = min(log_re_arr)
+    max_log_re = max(log_re_arr)
+    min_mach = min(mach_arr)
+    max_mach = max(mach_arr)
+
+    log_re_span = max_log_re - min_log_re
+    mach_span = max_mach - min_mach
+
+    # mach_scale converts mach to equivalent log-re units
+    mach_scale = log_re_span / mach_span if mach_span > 0 else 1.0
+
+    values: dict[str, list[float]] = {k: [] for k in _INTERPOLATED_KEYS}
+    for c in conditions:
+        for k in _INTERPOLATED_KEYS:
+            values[k].append(c[k])
+
+    processed = {
+        "log_re_arr": log_re_arr,
+        "mach_arr": mach_arr,
+        "values": values,
+        "re_range": (min(c["Re"] for c in conditions), max(c["Re"] for c in conditions)),
+        "mach_range": (min_mach, max_mach),
+        "mach_scale": mach_scale,
+        "min_log_re": min_log_re,
+        "max_log_re": max_log_re,
+    }
+    _PROCESSED_CACHE[stem] = processed
+    return processed
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp value to [lo, hi]."""
+    return max(lo, min(hi, value))
+
+
+def interpolate_section_aero(
+    airfoil_name: str,
+    Re: float,
+    Mach: float,
+) -> dict[str, float]:
+    """Interpolate section aerodynamic constants at (Re, Mach).
+
+    Uses k-nearest-neighbor inverse-distance-weighted interpolation in the
+    normalized (log Re, Mach) space. The Mach axis is scaled to match the
+    log-Re range so both dimensions contribute proportionally.
+
+    If Re/Mach is outside the grid bounds, clamps to the nearest boundary
+    (returns boundary values — no exception, no NaN).
+
+    Args:
+        airfoil_name: CHENG airfoil name (e.g. "NACA-2412", "Clark-Y").
+        Re: Reynolds number (e.g. 300000). Must be > 0.
+        Mach: Mach number (e.g. 0.05). Must be > 0.
+
+    Returns:
+        dict with keys: cl_alpha_per_rad, cm_ac, cl_max, cd_min, cl_at_cd_min.
+        All values are finite floats.
+    """
+    doc = load_airfoil_constants(airfoil_name)
+    stem = _stem_for_name(airfoil_name)
+    proc = _get_processed(stem)
+
+    log_re_arr = proc["log_re_arr"]
+    mach_arr = proc["mach_arr"]
+    values = proc["values"]
+    mach_scale = proc["mach_scale"]
+
+    # Clamp query to grid bounds
+    min_re, max_re = proc["re_range"]
+    min_mach, max_mach = proc["mach_range"]
+    re_clamped = _clamp(Re, min_re, max_re)
+    mach_clamped = _clamp(Mach, min_mach, max_mach)
+
+    log_re_q = math.log(re_clamped)
+    mach_q = mach_clamped
+
+    n = len(log_re_arr)
+    k = min(_K_NEIGHBORS, n)
+
+    # Compute squared distances in normalized (log_re, scaled_mach) space
+    dists: list[tuple[float, int]] = []
+    for i in range(n):
+        d_lr = log_re_q - log_re_arr[i]
+        d_m = (mach_q - mach_arr[i]) * mach_scale
+        dist2 = d_lr * d_lr + d_m * d_m
+        dists.append((dist2, i))
+
+    # Sort by distance, take k nearest
+    dists.sort(key=lambda x: x[0])
+    nearest = dists[:k]
+
+    # Check for exact match
+    if nearest[0][0] < 1e-14:
+        idx = nearest[0][1]
+        return {key: values[key][idx] for key in _INTERPOLATED_KEYS}
+
+    # Inverse-distance-weighted interpolation
+    weights = [1.0 / max(d2, 1e-30) for d2, _ in nearest]
+    total_weight = sum(weights)
+
+    result: dict[str, float] = {}
+    for key in _INTERPOLATED_KEYS:
+        val_arr = values[key]
+        weighted_sum = sum(weights[j] * val_arr[nearest[j][1]] for j in range(k))
+        result[key] = weighted_sum / total_weight
+
+    return result

--- a/backend/datcom.py
+++ b/backend/datcom.py
@@ -1,0 +1,833 @@
+"""
+backend/datcom.py
+
+USAF DATCOM empirical stability derivatives and dynamic mode analysis.
+
+This module implements the core aerodynamics pipeline:
+  1. Compute ISA flight condition (V, rho, q_bar, CL_trim)
+  2. Compute stability derivatives using DATCOM empirical formulas, with
+     section lift slopes supplied by NeuralFoil data (backend/airfoil_data.py)
+  3. Assemble linearized equations of motion and compute dynamic mode
+     characteristics via numpy eigenvalue analysis
+
+All units are SI internally (kg, m, s, rad). Input geometry is in mm (CHENG
+convention) and converted to metres at the start of each public function.
+
+References:
+  USAF DATCOM: Hoak, D.E. et al., "USAF Stability and Control DATCOM",
+  Report AFWAL-TR-83-3048 (1978, rev. 1998)
+  Lanchester, F.W., "Aerodonetics" (1908) — phugoid approximation
+  Nelson, R.C., "Flight Stability and Automatic Control" (1998)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from backend.models import AircraftDesign
+    from backend.mass_properties import MassProperties
+
+from backend.airfoil_data import interpolate_section_aero
+
+# ---------------------------------------------------------------------------
+# Physical constants
+# ---------------------------------------------------------------------------
+
+_G = 9.80665      # Standard gravity (m/s²)
+_MU = 1.81e-5     # Air dynamic viscosity at sea level (Pa·s)
+_SPEED_OF_SOUND_SL = 340.3  # Speed of sound at sea level (m/s)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FlightCondition:
+    """Trimmed flight condition derived from design parameters."""
+
+    speed_ms: float
+    """True airspeed (m/s)."""
+
+    altitude_m: float
+    """Flight altitude above MSL (m)."""
+
+    rho: float
+    """Air density at altitude (kg/m³)."""
+
+    q_bar: float
+    """Dynamic pressure = 0.5 * rho * V² (Pa)."""
+
+    CL_trim: float
+    """Trim lift coefficient at cruise (dimensionless)."""
+
+    alpha_trim_rad: float
+    """Trim angle of attack (rad). Approximate."""
+
+
+@dataclass
+class StabilityDerivatives:
+    """DATCOM stability derivatives (all per radian unless noted).
+
+    All values are non-dimensional except where otherwise stated.
+    """
+
+    # ── Longitudinal ─────────────────────────────────────────────────────────
+    CL_alpha: float
+    """Aircraft lift curve slope dCL/dα (per rad). Typically 4–7 /rad."""
+
+    CD_alpha: float
+    """Drag slope dCD/dα (per rad)."""
+
+    Cm_alpha: float
+    """Pitch stiffness dCm/dα (per rad). Must be negative for stability."""
+
+    CL_q: float
+    """Lift due to pitch rate (per rad)."""
+
+    Cm_q: float
+    """Pitch damping dCm/d(qc/2V) (per rad). Must be negative."""
+
+    CL_alphadot: float
+    """Lift due to angle-of-attack rate (per rad)."""
+
+    Cm_alphadot: float
+    """Pitch due to angle-of-attack rate (per rad)."""
+
+    # ── Lateral/directional ───────────────────────────────────────────────────
+    CY_beta: float
+    """Side force due to sideslip (per rad). Negative."""
+
+    Cl_beta: float
+    """Roll moment due to sideslip — dihedral effect (per rad). Negative = stable."""
+
+    Cn_beta: float
+    """Yaw moment due to sideslip — weathercock stability (per rad). Positive = stable."""
+
+    CY_p: float
+    """Side force due to roll rate."""
+
+    Cl_p: float
+    """Roll damping dCl/d(pb/2V) (per rad). Negative."""
+
+    Cn_p: float
+    """Yaw due to roll rate — adverse yaw (per rad)."""
+
+    CY_r: float
+    """Side force due to yaw rate."""
+
+    Cl_r: float
+    """Roll due to yaw rate (per rad). Positive for most configs."""
+
+    Cn_r: float
+    """Yaw damping dCn/d(rb/2V) (per rad). Negative."""
+
+
+@dataclass
+class DynamicModes:
+    """Dynamic stability mode characteristics.
+
+    Contains eigenvalue-derived parameters for all 5 classical dynamic modes.
+    All frequencies in rad/s; periods in seconds; time constants in seconds.
+    """
+
+    # ── Longitudinal ─────────────────────────────────────────────────────────
+    sp_omega_n: float
+    """Short-period natural frequency (rad/s)."""
+
+    sp_zeta: float
+    """Short-period damping ratio (dimensionless)."""
+
+    sp_period_s: float
+    """Short-period period (s). Large value if over-damped."""
+
+    phugoid_omega_n: float
+    """Phugoid natural frequency (rad/s)."""
+
+    phugoid_zeta: float
+    """Phugoid damping ratio."""
+
+    phugoid_period_s: float
+    """Phugoid period (s)."""
+
+    # ── Lateral/directional ───────────────────────────────────────────────────
+    dr_omega_n: float
+    """Dutch roll natural frequency (rad/s)."""
+
+    dr_zeta: float
+    """Dutch roll damping ratio."""
+
+    dr_period_s: float
+    """Dutch roll period (s)."""
+
+    roll_tau_s: float
+    """Roll mode time constant (s). Smaller = more responsive."""
+
+    spiral_tau_s: float
+    """Spiral mode time constant (s). Negative = divergent."""
+
+    spiral_t2_s: float
+    """Spiral time-to-double (s). math.inf for stable or convergent spiral."""
+
+    # Derivative passthrough for engine.py convenience
+    # (combined with StabilityDerivatives when creating DynamicStabilityResult)
+    CL_alpha: float = 0.0
+    CD_alpha: float = 0.0
+    Cm_alpha: float = 0.0
+    CL_q: float = 0.0
+    Cm_q: float = 0.0
+    CL_alphadot: float = 0.0
+    Cm_alphadot: float = 0.0
+    CY_beta: float = 0.0
+    Cl_beta: float = 0.0
+    Cn_beta: float = 0.0
+    CY_p: float = 0.0
+    Cl_p: float = 0.0
+    Cn_p: float = 0.0
+    CY_r: float = 0.0
+    Cl_r: float = 0.0
+    Cn_r: float = 0.0
+
+    derivatives_estimated: bool = True
+
+
+# ---------------------------------------------------------------------------
+# ISA atmosphere model
+# ---------------------------------------------------------------------------
+
+def _isa_atmosphere(altitude_m: float) -> tuple[float, float, float]:
+    """ISA standard atmosphere up to 11 km (troposphere).
+
+    Returns:
+        (T_K, rho_kg_m3, speed_of_sound_m_s)
+    """
+    # DATCOM uses standard ISA: linear temperature lapse in troposphere
+    T = 288.15 - 0.0065 * min(altitude_m, 11000.0)
+    rho = 1.225 * (T / 288.15) ** 4.256
+    a = _SPEED_OF_SOUND_SL * math.sqrt(T / 288.15)
+    return T, rho, a
+
+
+# ---------------------------------------------------------------------------
+# Finite-wing lift slope (DATCOM §4.1.3.2 — Polhamus)
+# ---------------------------------------------------------------------------
+
+def _finite_wing_cla(
+    a_0: float,
+    AR: float,
+    sweep_le_rad: float,
+    mach: float,
+) -> float:
+    """Polhamus finite-wing lift curve slope (per rad).
+
+    # DATCOM §4.1.3.2
+
+    a_0: section lift slope from NeuralFoil (per rad)
+    AR: aspect ratio
+    sweep_le_rad: leading-edge sweep angle (rad), positive aft
+    mach: Mach number
+    """
+    # Half-chord sweep from LE sweep approximation:
+    # Lambda_c2 ≈ Lambda_LE for thin wings (conservative)
+    sweep_c2 = sweep_le_rad  # approximate
+
+    beta = math.sqrt(max(1.0 - mach ** 2, 0.01))  # compressibility
+
+    # Polhamus formula (DATCOM eq. 4.1.3.2-a)
+    discriminant = 4.0 + (AR ** 2) * (1.0 + math.tan(sweep_c2) ** 2 / beta ** 2) * (a_0 / math.pi) ** 2
+    a_w = (a_0 * AR) / (2.0 + math.sqrt(max(discriminant, 0.01)))
+    return a_w
+
+
+# ---------------------------------------------------------------------------
+# Helper: compute Re and Mach for a lifting surface
+# ---------------------------------------------------------------------------
+
+def _surface_re_mach(
+    speed_ms: float,
+    chord_m: float,
+    sweep_rad: float,
+    rho: float,
+    speed_of_sound: float,
+) -> tuple[float, float]:
+    """Compute Re and Mach for a lifting surface, accounting for sweep.
+
+    Effective velocity normal to the leading edge:
+        V_eff = V * cos(sweep)
+    """
+    V_eff = speed_ms * math.cos(sweep_rad)
+    Re = rho * V_eff * chord_m / _MU
+    Mach = V_eff / speed_of_sound
+    return max(Re, 1.0), max(Mach, 1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Public function 1: compute_flight_condition
+# ---------------------------------------------------------------------------
+
+def compute_flight_condition(
+    design: "AircraftDesign",
+    mass_props: "MassProperties",
+) -> FlightCondition:
+    """Compute the trimmed flight condition for DATCOM analysis.
+
+    # DATCOM §1.2 (flight condition definitions)
+
+    Args:
+        design: Aircraft design parameters.
+        mass_props: Resolved mass properties (from resolve_mass_properties).
+
+    Returns:
+        FlightCondition with V, rho, q_bar, CL_trim, alpha_trim.
+    """
+    V = design.flight_speed_ms
+    h = design.flight_altitude_m
+
+    _, rho, _ = _isa_atmosphere(h)
+    q_bar = 0.5 * rho * V ** 2
+
+    # Wing reference area (m²)
+    tip_chord_m = (design.wing_chord * design.wing_tip_root_ratio) / 1000.0
+    root_chord_m = design.wing_chord / 1000.0
+    span_m = design.wing_span / 1000.0
+    S_w_m2 = 0.5 * (root_chord_m + tip_chord_m) * span_m  # both halves
+
+    mass_kg = mass_props.mass_g / 1000.0
+    weight_N = mass_kg * _G
+
+    CL_trim = weight_N / (q_bar * S_w_m2) if q_bar > 0 else 0.0
+
+    # Approximate alpha_trim using a_0 ~ 2*pi and AR correction
+    # Will be refined in derivatives step
+    AR = span_m ** 2 / max(S_w_m2, 0.001)
+    a_w_approx = (2.0 * math.pi * AR) / (2.0 + math.sqrt(4.0 + AR ** 2))
+    alpha_trim_rad = CL_trim / max(a_w_approx, 0.1)
+
+    return FlightCondition(
+        speed_ms=V,
+        altitude_m=h,
+        rho=rho,
+        q_bar=q_bar,
+        CL_trim=CL_trim,
+        alpha_trim_rad=alpha_trim_rad,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public function 2: compute_stability_derivatives
+# ---------------------------------------------------------------------------
+
+def compute_stability_derivatives(
+    design: "AircraftDesign",
+    mass_props: "MassProperties",
+    flight_cond: FlightCondition,
+) -> StabilityDerivatives:
+    """Compute DATCOM stability derivatives using NeuralFoil section data.
+
+    All formulas reference DATCOM section numbers in inline comments.
+    All lifting surface section slopes use NeuralFoil interpolation, NOT 2*pi.
+
+    Args:
+        design: Aircraft design parameters.
+        mass_props: Resolved mass properties.
+        flight_cond: Trimmed flight condition.
+
+    Returns:
+        StabilityDerivatives with all 16 derivatives.
+    """
+    V = flight_cond.speed_ms
+    rho = flight_cond.rho
+    q_bar = flight_cond.q_bar
+    CL_trim = flight_cond.CL_trim
+
+    _, _, speed_of_sound = _isa_atmosphere(flight_cond.altitude_m)
+
+    # ── Geometry (SI) ───────────────────────────────────────────────────────
+    b_m = design.wing_span / 1000.0
+    root_chord_m = design.wing_chord / 1000.0
+    tip_chord_m = root_chord_m * design.wing_tip_root_ratio
+    S_w_m2 = 0.5 * (root_chord_m + tip_chord_m) * b_m
+    c_bar_m = 2.0 / 3.0 * root_chord_m * (
+        (1.0 + design.wing_tip_root_ratio + design.wing_tip_root_ratio ** 2)
+        / (1.0 + design.wing_tip_root_ratio)
+    )  # Mean aerodynamic chord
+    AR = b_m ** 2 / max(S_w_m2, 0.001)
+    lam = design.wing_tip_root_ratio  # taper ratio
+
+    sweep_le_rad = math.radians(design.wing_sweep)
+
+    # Flying wing / BWB: no separate tail surfaces
+    is_flying_wing = design.fuselage_preset == "Blended-Wing-Body"
+
+    # ── Wing section aerodynamics (NeuralFoil) ─────────────────────────────
+    Re_w, Mach_w = _surface_re_mach(V, c_bar_m, sweep_le_rad, rho, speed_of_sound)
+    wing_aero = interpolate_section_aero(design.wing_airfoil, Re=Re_w, Mach=Mach_w)
+
+    a_0_w = wing_aero["cl_alpha_per_rad"]  # NeuralFoil section slope — NOT 2π
+    cd_min_w = wing_aero["cd_min"]
+    cm_ac_w = wing_aero["cm_ac"]
+
+    # ── Finite-wing lift slope (DATCOM §4.1.3.2) ───────────────────────────
+    a_w = _finite_wing_cla(a_0_w, AR, sweep_le_rad, Mach_w)
+
+    # ── Downwash gradient at horizontal tail (DATCOM §5.1) ─────────────────
+    # Approximate formula for unswept/lightly swept wings:
+    # dε/dα ≈ 2 * a_w / (π * AR)
+    # # DATCOM §5.1.3.1
+    de_da = 2.0 * a_w / (math.pi * AR)
+    de_da = min(de_da, 0.9)  # physical limit
+
+    # ── Tail geometry ─────────────────────────────────────────────────────
+    if not is_flying_wing:
+        if design.tail_type == "V-Tail":
+            # V-tail: project to effective horizontal and vertical areas
+            dih = math.radians(design.v_tail_dihedral)
+            S_tail_per_surface = design.v_tail_chord * design.v_tail_span / 1e6  # m²
+            # Both surfaces
+            S_h_eff = 2.0 * S_tail_per_surface * math.cos(dih) ** 2
+            S_v_eff = 2.0 * S_tail_per_surface * math.sin(dih) ** 2
+            h_chord_m = design.v_tail_chord / 1000.0
+            v_chord_m = design.v_tail_chord / 1000.0
+            sweep_h_rad = math.radians(design.v_tail_sweep)
+            sweep_v_rad = sweep_h_rad
+            h_span_m = design.v_tail_span / 1000.0
+            v_height_m = design.v_tail_span * math.sin(dih) / 1000.0
+            l_t_m = design.tail_arm / 1000.0
+            l_v_m = l_t_m
+        else:
+            # Conventional / T-Tail / Cruciform
+            S_h_eff = design.h_stab_chord * design.h_stab_span / 1e6  # m²
+            S_v_eff = 0.5 * design.v_stab_root_chord * design.v_stab_height / 1e6  # m² (triangle approx)
+            h_chord_m = design.h_stab_chord / 1000.0
+            v_chord_m = design.v_stab_root_chord / 1000.0
+            sweep_h_rad = 0.0  # h-stab usually unswept
+            sweep_v_rad = 0.0
+            h_span_m = design.h_stab_span / 1000.0
+            v_height_m = design.v_stab_height / 1000.0
+            l_t_m = design.tail_arm / 1000.0
+            l_v_m = l_t_m  # same arm for conventional tail
+
+        # Horizontal tail section aerodynamics (NeuralFoil)
+        Re_h, Mach_h = _surface_re_mach(V, h_chord_m, sweep_h_rad, rho, speed_of_sound)
+        tail_aero = interpolate_section_aero(design.tail_airfoil, Re=Re_h, Mach=Mach_h)
+        a_0_t = tail_aero["cl_alpha_per_rad"]
+
+        # Horizontal tail aspect ratio and lift slope
+        AR_h = h_span_m ** 2 / max(S_h_eff, 0.001)
+        a_t = _finite_wing_cla(a_0_t, AR_h, sweep_h_rad, Mach_h)
+
+        # Vertical tail section aerodynamics
+        Re_v, Mach_v = _surface_re_mach(V, v_chord_m, sweep_v_rad, rho, speed_of_sound)
+        vtail_aero = interpolate_section_aero(design.tail_airfoil, Re=Re_v, Mach=Mach_v)
+        a_0_v = vtail_aero["cl_alpha_per_rad"]
+
+        # Vertical fin effective aspect ratio
+        AR_v = 2.0 * v_height_m ** 2 / max(S_v_eff, 0.001)  # factor 2 for endplate effect
+        a_v = _finite_wing_cla(a_0_v, AR_v, sweep_v_rad, Mach_v)
+
+        # Efficiency factors
+        eta_t = 0.90   # horizontal tail dynamic pressure ratio
+        eta_v = 0.90   # vertical fin dynamic pressure ratio
+
+        # Volume ratios
+        V_h = a_t * eta_t * S_h_eff / S_w_m2  # horizontal tail volume-like ratio
+        V_v = a_v * eta_v * S_v_eff / S_w_m2  # vertical fin volume-like ratio
+
+        # Vertical fin height above CG (approximate: half fin height)
+        z_v_m = v_height_m / 2.0
+
+    else:
+        # Flying wing: no separate tail surfaces
+        # Set all tail contributions to zero
+        a_t = 0.0
+        a_v = 0.0
+        S_h_eff = 0.0
+        S_v_eff = 0.0
+        eta_t = 0.0
+        eta_v = 0.0
+        V_h = 0.0
+        V_v = 0.0
+        l_t_m = design.fuselage_length * 0.3 / 1000.0  # approximate
+        l_v_m = l_t_m
+        z_v_m = 0.0
+        de_da = 0.0  # no downwash without ht for flying wing
+
+    # ── CG and AC positions (fraction of MAC) ─────────────────────────────
+    cg_x_mm = mass_props.cg_x_mm
+    # Wing mount position (approximate)
+    x_ac_w = 0.25  # aerodynamic center at 25% MAC for subsonic
+
+    # CG as fraction of MAC from nose of MAC
+    # We need x_cg_mac: CG position measured from wing LE as fraction of c_bar
+    # estimate wing leading edge position
+    wing_x_m = design.fuselage_length * 0.30 / 1000.0  # approx mount fraction
+    cg_x_m = cg_x_mm / 1000.0
+    x_ac_w_m = wing_x_m + x_ac_w * c_bar_m
+    x_cg_mac = (cg_x_m - wing_x_m) / max(c_bar_m, 0.001)  # fraction of MAC
+
+    # ── Longitudinal derivatives ─────────────────────────────────────────
+
+    # CLα — total aircraft lift slope (DATCOM §4.1.3.2, §4.5)
+    # # DATCOM §4.5 — wing + tail + fuselage body factor
+    K_WB = 1.07  # Wing-Body interference factor (conventional layout)
+    CL_alpha = K_WB * a_w + a_t * eta_t * (S_h_eff / S_w_m2) * (1.0 - de_da)
+
+    # CDα — drag slope (DATCOM §4.1.5)
+    # # DATCOM §4.1.5 — induced drag contribution
+    e_oswald = 0.80  # Oswald efficiency factor
+    CD0 = cd_min_w + CL_trim ** 2 / (math.pi * AR * e_oswald)
+    CD_alpha = 2.0 * CL_trim / (math.pi * AR * e_oswald)
+
+    # Cmα — pitch stiffness (DATCOM §4.5)
+    # # DATCOM §4.5 — wing-body + tail contributions
+    Cm_alpha = (
+        a_w * K_WB * (x_cg_mac - x_ac_w)
+        - a_t * eta_t * (S_h_eff / S_w_m2) * (l_t_m / c_bar_m) * (1.0 - de_da)
+    )
+
+    # CLq — lift due to pitch rate (DATCOM §7.1)
+    # # DATCOM §7.1 — tail contribution dominates
+    CL_q = 2.0 * a_t * eta_t * (S_h_eff / S_w_m2) * (l_t_m / c_bar_m)
+
+    # Cmq — pitch damping (DATCOM §7.1)
+    # # DATCOM §7.1 — must be negative
+    Cm_q = -2.0 * a_t * eta_t * (S_h_eff / S_w_m2) * (l_t_m / c_bar_m) ** 2
+
+    # CLalphadot, Cmalphadot — downwash-lag derivatives (DATCOM §7.1.2)
+    # # DATCOM §7.1.2 — apparent mass terms
+    CL_alphadot = 2.0 * a_t * eta_t * (S_h_eff / S_w_m2) * (l_t_m / c_bar_m) * de_da
+    Cm_alphadot = -CL_alphadot * (l_t_m / c_bar_m)
+
+    # ── Lateral/directional derivatives ─────────────────────────────────
+
+    # CYβ — side force due to sideslip (DATCOM §6.1.4)
+    # # DATCOM §6.1.4 — vertical fin contribution
+    dsigma_dbeta = 0.20  # sidewash gradient (typical conventional fuselage)
+    CY_beta = -a_v * eta_v * (S_v_eff / S_w_m2) * (1.0 + dsigma_dbeta)
+
+    # Clβ — dihedral effect (DATCOM §6.1.5)
+    # # DATCOM §6.1.5 — dihedral + sweep + fin contributions
+    Gamma_eff_rad = math.radians(design.wing_dihedral)  # geometric dihedral
+    Cl_beta_dihedral = -(a_0_w / (2.0 * math.pi)) * Gamma_eff_rad  # uses NeuralFoil slope
+    Cl_beta_sweep = -CL_trim * math.tan(sweep_le_rad) / (4.0 * AR) if AR > 0 else 0.0
+    Cl_beta_fin = -a_v * eta_v * (S_v_eff / S_w_m2) * (z_v_m / b_m)
+    Cl_beta = Cl_beta_dihedral + Cl_beta_sweep + Cl_beta_fin
+
+    # Cnβ — directional stability (DATCOM §6.1.4)
+    # # DATCOM §6.1.4 — fin + wing + fuselage contributions
+    Cn_beta_fin = a_v * eta_v * (S_v_eff / S_w_m2) * (l_v_m / b_m)
+    Cn_beta_wing = -CL_trim * (1.0 - 3.0 * lam) / (6.0 * (1.0 + lam)) * math.tan(sweep_le_rad)
+
+    # Fuselage contribution (destabilizing)
+    # # DATCOM §6.1.4 — body contribution: k_n * k_rl * S_B_side * l_fus / (S_w * b)
+    k_n = 0.01  # fuselage fineness correction (small for conventional fuselages)
+    k_rl = 1.0  # Reynolds number correction (= 1.0 at Re > 1e5)
+    S_B_side_m2 = (design.fuselage_length * design.wing_chord * 0.35) / 1e6  # approx side area
+    l_fus_m = design.fuselage_length / 1000.0
+    Cn_beta_fuselage = -k_n * k_rl * (S_B_side_m2 * l_fus_m) / (S_w_m2 * b_m)
+
+    Cn_beta = Cn_beta_fin + Cn_beta_wing + Cn_beta_fuselage
+
+    # Clp — roll damping (DATCOM §7.3)
+    # # DATCOM §7.3 — wing roll damping, uses NeuralFoil section slope
+    Cl_p = -(a_0_w / 8.0) * (1.0 + 3.0 * lam) / (1.0 + lam)  # per rad
+
+    # Cnr — yaw damping (DATCOM §7.4)
+    # # DATCOM §7.4 — fin + wing contributions
+    Cn_r_fin = -a_v * eta_v * (S_v_eff / S_w_m2) * (l_v_m / b_m) ** 2
+    Cn_r_wing = -(CL_trim ** 2 / (math.pi * AR) + cd_min_w / 8.0)
+    Cn_r = Cn_r_fin + Cn_r_wing
+
+    # Clr — roll due to yaw rate (DATCOM §7.4)
+    # # DATCOM §7.4 — coupling derivative
+    Cl_r_wing = CL_trim / 4.0
+    Cl_r_fin = a_v * eta_v * (S_v_eff / S_w_m2) * (z_v_m / b_m) * (l_v_m / b_m)
+    Cl_r = Cl_r_wing + Cl_r_fin
+
+    # Cnp — yaw due to roll rate (DATCOM §7.5)
+    # # DATCOM §7.5 — adverse yaw
+    Cn_p = -CL_trim / 8.0 * (1.0 - 3.0 * lam) / (1.0 + lam)
+
+    # CYp, CYr — side force rate derivatives (DATCOM §7.5, §7.4)
+    # # DATCOM §7.5/7.4 — secondary terms
+    CY_p = -a_v * eta_v * (S_v_eff / S_w_m2) * (z_v_m / b_m)
+    CY_r = 2.0 * a_v * eta_v * (S_v_eff / S_w_m2) * (l_v_m / b_m)
+
+    return StabilityDerivatives(
+        CL_alpha=CL_alpha,
+        CD_alpha=CD_alpha,
+        Cm_alpha=Cm_alpha,
+        CL_q=CL_q,
+        Cm_q=Cm_q,
+        CL_alphadot=CL_alphadot,
+        Cm_alphadot=Cm_alphadot,
+        CY_beta=CY_beta,
+        Cl_beta=Cl_beta,
+        Cn_beta=Cn_beta,
+        CY_p=CY_p,
+        Cl_p=Cl_p,
+        Cn_p=Cn_p,
+        CY_r=CY_r,
+        Cl_r=Cl_r,
+        Cn_r=Cn_r,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Eigenvalue helpers
+# ---------------------------------------------------------------------------
+
+def _damping_freq_from_eigenvalue(ev: complex) -> tuple[float, float, float]:
+    """Extract (omega_n, zeta, period_s) from a complex eigenvalue.
+
+    For a pair σ ± jω:
+        omega_n = sqrt(σ² + ω²)
+        zeta    = -σ / omega_n
+        period  = 2π / ω
+
+    Returns all zeros for non-oscillatory modes.
+    """
+    sigma = ev.real
+    omega_d = abs(ev.imag)
+    if omega_d < 1e-6:
+        return 0.0, 0.0, 0.0
+    omega_n = math.sqrt(sigma ** 2 + omega_d ** 2)
+    zeta = -sigma / omega_n if omega_n > 0 else 0.0
+    period = 2.0 * math.pi / omega_d
+    return omega_n, zeta, period
+
+
+# ---------------------------------------------------------------------------
+# Public function 3: compute_dynamic_modes
+# ---------------------------------------------------------------------------
+
+def compute_dynamic_modes(
+    design: "AircraftDesign",
+    mass_props: "MassProperties",
+    flight_cond: FlightCondition,
+    derivs: StabilityDerivatives,
+) -> DynamicModes:
+    """Compute dynamic stability mode characteristics via eigenvalue analysis.
+
+    Assembles 4×4 longitudinal and lateral state matrices in dimensional form,
+    computes eigenvalues, and classifies the resulting modes.
+
+    Longitudinal state: [Δu, Δw, q, Δθ]
+    Lateral state: [β, p, r, φ]
+
+    # DATCOM §8.1 (dynamic stability equations)
+    # Nelson (1998) Chapters 4-5
+
+    Args:
+        design: Aircraft design.
+        mass_props: Resolved mass properties.
+        flight_cond: Trimmed flight condition.
+        derivs: Stability derivatives (from compute_stability_derivatives).
+
+    Returns:
+        DynamicModes with all mode characteristics.
+    """
+    V = flight_cond.speed_ms
+    rho = flight_cond.rho
+    q_bar = flight_cond.q_bar
+    CL_trim = flight_cond.CL_trim
+    alpha_0 = flight_cond.alpha_trim_rad
+
+    # ── Geometry and mass (SI) ─────────────────────────────────────────────
+    b_m = design.wing_span / 1000.0
+    root_chord_m = design.wing_chord / 1000.0
+    tip_chord_m = root_chord_m * design.wing_tip_root_ratio
+    S_w_m2 = 0.5 * (root_chord_m + tip_chord_m) * b_m
+    c_bar_m = 2.0 / 3.0 * root_chord_m * (
+        (1.0 + design.wing_tip_root_ratio + design.wing_tip_root_ratio ** 2)
+        / (1.0 + design.wing_tip_root_ratio)
+    )
+
+    m_kg = mass_props.mass_g / 1000.0
+    W_N = m_kg * _G
+    Ixx = mass_props.ixx_kg_m2
+    Iyy = mass_props.iyy_kg_m2
+    Izz = mass_props.izz_kg_m2
+
+    # ── Non-dimensional → dimensional conversion shortcuts ─────────────────
+    qS = q_bar * S_w_m2
+    qSc = qS * c_bar_m
+    qSb = qS * b_m
+    qSb2 = qSb * b_m
+
+    # Non-dimensional time unit
+    t_star = c_bar_m / (2.0 * V)   # longitudinal
+    t_b = b_m / (2.0 * V)          # lateral
+
+    # ── Longitudinal state matrix A_long (dimensional) ─────────────────────
+    # State: [Δu, Δw, q, Δθ]
+    # Reference: Nelson (1998) eq. 4.52
+
+    # Dimensional stability derivatives
+    X_u = -qS * (2.0 * CL_trim * math.sin(alpha_0) + derivs.CD_alpha * math.cos(alpha_0)) / (m_kg * V)
+    X_w = qS * (CL_trim * math.cos(alpha_0) - derivs.CD_alpha * math.sin(alpha_0)) / (m_kg * V)
+    Z_u = -qS * (2.0 * CL_trim * math.cos(alpha_0) + derivs.CD_alpha * math.sin(alpha_0)) / (m_kg * V)
+    Z_w = -qS * derivs.CL_alpha / (m_kg * V)
+    Z_q = qS * derivs.CL_q * c_bar_m / (2.0 * m_kg * V)
+    Z_adot = qS * derivs.CL_alphadot * c_bar_m / (2.0 * m_kg * V)
+    M_w = qSc * derivs.Cm_alpha / (Iyy * V)
+    M_q = qSc * derivs.Cm_q * c_bar_m / (2.0 * Iyy * V)
+    M_adot = qSc * derivs.Cm_alphadot * c_bar_m / (2.0 * Iyy * V)
+
+    # A_long in [Δu, Δw, q, Δθ]
+    # Row 0: Δu_dot = X_u*Δu + X_w*Δw - g*cos(theta0)*Δθ
+    # Row 1: Δw_dot = Z_u*Δu + Z_w*Δw + (V + Z_q)*q - g*sin(theta0)*Δθ  (approx θ0~α0)
+    # Row 2: q_dot  = M_u*Δu + (M_w + M_adot*Z_w/V)*Δw + M_q*q + M_adot*Z_q/V*q (simplified)
+    # Row 3: θ_dot  = q
+
+    theta0 = alpha_0  # assume theta0 ~ alpha0 for level flight
+
+    A_long = np.array([
+        [X_u,   X_w,   0.0,          -_G * math.cos(theta0)],
+        [Z_u,   Z_w,   V + Z_q,      -_G * math.sin(theta0)],
+        [0.0,   M_w + M_adot * Z_w / V,  M_q + M_adot * (V + Z_q) / V,  0.0],
+        [0.0,   0.0,   1.0,           0.0],
+    ], dtype=float)
+
+    # ── Lateral state matrix A_lat (dimensional) ───────────────────────────
+    # State: [β, p, r, φ]
+    # Reference: Nelson (1998) eq. 5.31
+
+    Y_beta = qS * derivs.CY_beta / (m_kg * V)
+    Y_p = qS * derivs.CY_p * b_m / (2.0 * m_kg * V)
+    Y_r = qS * derivs.CY_r * b_m / (2.0 * m_kg * V)
+    L_beta = qSb * derivs.Cl_beta / Ixx
+    L_p = qSb2 * derivs.Cl_p / (2.0 * Ixx * V)
+    L_r = qSb2 * derivs.Cl_r / (2.0 * Ixx * V)
+    N_beta = qSb * derivs.Cn_beta / Izz
+    N_p = qSb2 * derivs.Cn_p / (2.0 * Izz * V)
+    N_r = qSb2 * derivs.Cn_r / (2.0 * Izz * V)
+
+    A_lat = np.array([
+        [Y_beta,    1.0 + Y_p,    -(1.0 - Y_r),   _G / V],
+        [L_beta,    L_p,           L_r,            0.0   ],
+        [N_beta,    N_p,           N_r,            0.0   ],
+        [0.0,       1.0,           0.0,            0.0   ],
+    ], dtype=float)
+
+    # ── Longitudinal eigenvalues ───────────────────────────────────────────
+    try:
+        evals_long = np.linalg.eig(A_long)[0]
+        # Sort by magnitude of real part (largest = short-period, smallest = phugoid)
+        evals_long_sorted = sorted(evals_long, key=lambda e: abs(e.real), reverse=True)
+
+        # Short-period: largest |real| eigenvalue (complex pair)
+        sp_ev = evals_long_sorted[0]
+        sp_omega_n, sp_zeta, sp_period_s = _damping_freq_from_eigenvalue(sp_ev)
+
+        # Phugoid: smallest |real| (complex pair)
+        ph_ev = evals_long_sorted[2]  # index 2 (pair: 0,1 = SP, 2,3 = phugoid)
+        ph_omega_n, ph_zeta, ph_period_s = _damping_freq_from_eigenvalue(ph_ev)
+
+        # Use Lanchester approximation as sanity check for phugoid
+        ph_omega_lanchester = _G * math.sqrt(2.0) / V
+        if ph_omega_n < 1e-6 or not math.isfinite(ph_omega_n):
+            ph_omega_n = ph_omega_lanchester
+            ph_period_s = 2.0 * math.pi / ph_omega_n
+
+    except Exception as e:
+        warnings.warn(f"Longitudinal eigenvalue computation failed: {e}")
+        # Fallback: Lanchester approximation for phugoid
+        ph_omega_n = _G * math.sqrt(2.0) / V
+        ph_zeta = 0.05
+        ph_period_s = 2.0 * math.pi / ph_omega_n
+        sp_omega_n = max(abs(derivs.Cm_q), 0.5)
+        sp_zeta = 0.5
+        sp_period_s = 2.0 * math.pi / max(sp_omega_n, 0.01)
+
+    # ── Lateral eigenvalues ────────────────────────────────────────────────
+    try:
+        evals_lat = np.linalg.eig(A_lat)[0]
+
+        # Separate complex pairs (Dutch roll) from real roots (roll, spiral)
+        complex_evs = [e for e in evals_lat if abs(e.imag) > 1e-3]
+        real_evs = sorted(
+            [e.real for e in evals_lat if abs(e.imag) <= 1e-3],
+            key=lambda r: r  # ascending
+        )
+
+        # Dutch roll: complex conjugate pair
+        if complex_evs:
+            dr_ev = complex_evs[0]
+            dr_omega_n, dr_zeta, dr_period_s = _damping_freq_from_eigenvalue(dr_ev)
+        else:
+            dr_omega_n, dr_zeta, dr_period_s = 0.0, 0.0, 0.0
+
+        # Real roots: more negative = roll mode, less negative (or positive) = spiral
+        if len(real_evs) >= 2:
+            # Roll mode: most negative real eigenvalue (large negative = fast convergence)
+            roll_ev = min(real_evs)  # most negative
+            spiral_ev_val = max(real_evs)  # least negative (or positive = divergent)
+        elif len(real_evs) == 1:
+            roll_ev = real_evs[0]
+            spiral_ev_val = 0.0
+        else:
+            roll_ev = -2.0  # default
+            spiral_ev_val = 0.01
+
+        roll_tau_s = -1.0 / roll_ev if abs(roll_ev) > 1e-6 else 10.0
+        spiral_tau_s = 1.0 / spiral_ev_val if abs(spiral_ev_val) > 1e-6 else 1e6
+
+        # Time to double for spiral (divergent if spiral_ev_val > 0)
+        if spiral_ev_val > 1e-6:
+            spiral_t2_s = math.log(2.0) / spiral_ev_val
+        else:
+            spiral_t2_s = math.inf  # stable or neutral
+
+    except Exception as e:
+        warnings.warn(f"Lateral eigenvalue computation failed: {e}")
+        dr_omega_n, dr_zeta, dr_period_s = 1.0, 0.1, 6.0
+        roll_tau_s = 0.3
+        spiral_tau_s = 100.0
+        spiral_t2_s = math.inf
+
+    # Clamp NaN/inf to safe defaults
+    def _safe(val: float, default: float = 0.0) -> float:
+        if not math.isfinite(val):
+            return default
+        return val
+
+    return DynamicModes(
+        sp_omega_n=_safe(sp_omega_n, 2.0),
+        sp_zeta=_safe(sp_zeta, 0.5),
+        sp_period_s=_safe(sp_period_s, 2.0),
+        phugoid_omega_n=_safe(ph_omega_n, 0.1),
+        phugoid_zeta=_safe(ph_zeta, 0.05),
+        phugoid_period_s=_safe(ph_period_s, 60.0),
+        dr_omega_n=_safe(dr_omega_n, 1.0),
+        dr_zeta=_safe(dr_zeta, 0.1),
+        dr_period_s=_safe(dr_period_s, 4.0),
+        roll_tau_s=_safe(roll_tau_s, 0.3),
+        spiral_tau_s=_safe(spiral_tau_s, 100.0),
+        spiral_t2_s=spiral_t2_s if math.isinf(spiral_t2_s) else _safe(spiral_t2_s, 1000.0),
+        # Derivative passthrough
+        CL_alpha=derivs.CL_alpha,
+        CD_alpha=derivs.CD_alpha,
+        Cm_alpha=derivs.Cm_alpha,
+        CL_q=derivs.CL_q,
+        Cm_q=derivs.Cm_q,
+        CL_alphadot=derivs.CL_alphadot,
+        Cm_alphadot=derivs.Cm_alphadot,
+        CY_beta=derivs.CY_beta,
+        Cl_beta=derivs.Cl_beta,
+        Cn_beta=derivs.Cn_beta,
+        CY_p=derivs.CY_p,
+        Cl_p=derivs.Cl_p,
+        Cn_p=derivs.Cn_p,
+        CY_r=derivs.CY_r,
+        Cl_r=derivs.Cl_r,
+        Cn_r=derivs.Cn_r,
+        derivatives_estimated=True,
+    )

--- a/backend/datcom.py
+++ b/backend/datcom.py
@@ -710,8 +710,13 @@ def compute_dynamic_modes(
     N_p = qSb2 * derivs.Cn_p / (2.0 * Izz * V)
     N_r = qSb2 * derivs.Cn_r / (2.0 * Izz * V)
 
+    # Lateral state matrix for [β, p, r, φ], Nelson (1998) eq. 5.31, θ≈0.
+    # Row 1 (β): Y_β*β + Y_p*p + (Y_r - 1)*r + (g/V)*φ
+    #   The '-1' comes from the kinematic coupling: β̇ = ... - r (from v̇ = ... - u0*r)
+    #   Y_p and Y_r are already dimensional (qSb/(2mV) × CY_p/r).
+    # Row 4 (φ): φ̇ = p  (roll rate integrates to bank angle, θ≈0 so tan(θ)≈0)
     A_lat = np.array([
-        [Y_beta,    1.0 + Y_p,    -(1.0 - Y_r),   _G / V],
+        [Y_beta,    Y_p,           Y_r - 1.0,      _G / V],
         [L_beta,    L_p,           L_r,            0.0   ],
         [N_beta,    N_p,           N_r,            0.0   ],
         [0.0,       1.0,           0.0,            0.0   ],

--- a/backend/datcom.py
+++ b/backend/datcom.py
@@ -796,7 +796,10 @@ def compute_dynamic_modes(
             spiral_ev_val = 0.01
 
         roll_tau_s = -1.0 / roll_ev if abs(roll_ev) > 1e-6 else 10.0
-        spiral_tau_s = 1.0 / spiral_ev_val if abs(spiral_ev_val) > 1e-6 else 1e6
+        # spiral_tau_s convention: positive = stable/convergent, negative = divergent.
+        # Eigenvalue sign: stable spiral has s < 0, divergent has s > 0.
+        # tau = -1/s → stable: tau > 0, divergent: tau < 0.  Matches docstring.
+        spiral_tau_s = -1.0 / spiral_ev_val if abs(spiral_ev_val) > 1e-6 else 1e6
 
         # Time to double for spiral (divergent if spiral_ev_val > 0)
         if spiral_ev_val > 1e-6:

--- a/backend/datcom.py
+++ b/backend/datcom.py
@@ -720,15 +720,17 @@ def compute_dynamic_modes(
     # ── Longitudinal eigenvalues ───────────────────────────────────────────
     try:
         evals_long = np.linalg.eig(A_long)[0]
-        # Sort by magnitude of real part (largest = short-period, smallest = phugoid)
-        evals_long_sorted = sorted(evals_long, key=lambda e: abs(e.real), reverse=True)
+        # Sort by oscillation frequency |imag| (descending):
+        # short-period has HIGHER frequency than phugoid.
+        # Using abs(real) (damping) can mis-identify modes when phugoid is overdamped.
+        evals_long_sorted = sorted(evals_long, key=lambda e: abs(e.imag), reverse=True)
 
-        # Short-period: largest |real| eigenvalue (complex pair)
+        # Short-period: highest-frequency eigenvalue (complex pair, indices 0 & 1)
         sp_ev = evals_long_sorted[0]
         sp_omega_n, sp_zeta, sp_period_s = _damping_freq_from_eigenvalue(sp_ev)
 
-        # Phugoid: smallest |real| (complex pair)
-        ph_ev = evals_long_sorted[2]  # index 2 (pair: 0,1 = SP, 2,3 = phugoid)
+        # Phugoid: lowest-frequency eigenvalue (complex pair, indices 2 & 3)
+        ph_ev = evals_long_sorted[2]
         ph_omega_n, ph_zeta, ph_period_s = _damping_freq_from_eigenvalue(ph_ev)
 
         # Use Lanchester approximation as sanity check for phugoid

--- a/backend/mass_properties.py
+++ b/backend/mass_properties.py
@@ -179,10 +179,19 @@ def estimate_inertia(
     x_battery_from_cg = abs(x_battery_m - cg_x_m)
     I_battery_pitch = m_battery_kg * x_battery_from_cg ** 2
 
+    # ── Avionics contribution ─────────────────────────────────────────────
+    # Residual electronics (servos, ESC, receiver) are distributed inside the
+    # fuselage near the CG.  Model as a fuselage-like cylinder of the same
+    # cross-section so we reuse r_fus_m:
+    #   Ixx_avionics ≈ (1/2) * m * r²   (compact roll inertia)
+    #   Iyy_avionics ≈ (1/12) * m * (L² + 3r²)  (distributed along fuselage)
+    I_avionics_roll = 0.5 * m_avionics_kg * r_fus_m ** 2
+    I_avionics_pitch = (1.0 / 12.0) * m_avionics_kg * (L_m ** 2 + 3.0 * r_fus_m ** 2)
+
     # ── Assemble totals ───────────────────────────────────────────────────
-    ixx = I_wing_roll + I_fus_roll
-    iyy = I_wing_pitch + I_fus_pitch + I_tail_pitch + I_motor_pitch + I_battery_pitch
-    izz = I_wing_yaw + I_fus_pitch + I_tail_yaw + I_motor_pitch + I_battery_pitch
+    ixx = I_wing_roll + I_fus_roll + I_avionics_roll
+    iyy = I_wing_pitch + I_fus_pitch + I_tail_pitch + I_motor_pitch + I_battery_pitch + I_avionics_pitch
+    izz = I_wing_yaw + I_fus_pitch + I_tail_yaw + I_motor_pitch + I_battery_pitch + I_avionics_pitch
 
     # Ensure minimum plausible values and physical ordering constraint
     # (small floating point errors can break Ixx < Iyy < Izz in degenerate cases)

--- a/backend/mass_properties.py
+++ b/backend/mass_properties.py
@@ -246,7 +246,12 @@ def resolve_mass_properties(
     if design.cg_override_x_mm is not None:
         cg_x_mm = float(design.cg_override_x_mm)
     else:
-        cg_x_mm = _get(derived, "estimated_cg_mm")
+        # NOTE: derived["estimated_cg_mm"] is wing-LE-referenced (distance aft of
+        # wing root LE), not nose-referenced.  MassProperties.cg_x_mm is defined
+        # as nose-referenced.  We cannot convert without knowing wing_x here, so
+        # use 30% of fuselage length from nose — consistent with the conventional
+        # RC "balance at 25-30% MAC" rule and the engine's own fallback.
+        cg_x_mm = design.fuselage_length * 0.30
 
     if design.cg_override_z_mm is not None:
         cg_z_mm = float(design.cg_override_z_mm)

--- a/backend/mass_properties.py
+++ b/backend/mass_properties.py
@@ -109,9 +109,12 @@ def estimate_inertia(
     m_motor_kg = design.motor_weight_g / 1000.0
     m_battery_kg = design.battery_weight_g / 1000.0
 
-    # Total for distribution of electronics
-    m_avionics_kg = max(0.0, (_get(derived, "weight_total_g") / 1000.0)
-                        - m_wing_kg - m_tail_kg - m_fus_kg
+    # Total for distribution of electronics.
+    # weight_total_g (airframe geometry) + motor + battery = full aircraft mass.
+    # Subtract all known structural/propulsion components to get residual
+    # electronics (servos, ESC, receiver, wiring).
+    m_total_kg = (_get(derived, "weight_total_g") + design.motor_weight_g + design.battery_weight_g) / 1000.0
+    m_avionics_kg = max(0.0, m_total_kg - m_wing_kg - m_tail_kg - m_fus_kg
                         - m_motor_kg - m_battery_kg)
 
     # ── Key geometric dimensions (SI, metres) ─────────────────────────────

--- a/backend/mass_properties.py
+++ b/backend/mass_properties.py
@@ -217,7 +217,10 @@ def resolve_mass_properties(
     if design.mass_total_override_g is not None:
         mass_g = float(design.mass_total_override_g)
     else:
-        mass_g = _get(derived, "weight_total_g")
+        # weight_total_g from derived covers airframe only (wing + tail + fuselage).
+        # Motor and battery are separate design fields — add them for total aircraft mass.
+        airframe_g = _get(derived, "weight_total_g")
+        mass_g = airframe_g + design.motor_weight_g + design.battery_weight_g
 
     # ── CG position (MP02-MP04) ────────────────────────────────────────────
     if design.cg_override_x_mm is not None:

--- a/backend/mass_properties.py
+++ b/backend/mass_properties.py
@@ -1,0 +1,274 @@
+"""
+backend/mass_properties.py
+
+Mass properties module for CHENG dynamic stability analysis.
+
+Provides:
+- MassProperties dataclass: resolved mass, CG position, and moments of inertia
+- estimate_inertia(): component build-up inertia estimation
+- resolve_mass_properties(): applies MP01-MP07 overrides or falls back to estimates
+
+All internal computation is in SI units (kg, m, kg·m²).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    from backend.models import AircraftDesign, DerivedValues
+
+
+# ---------------------------------------------------------------------------
+# MassProperties dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MassProperties:
+    """Resolved mass properties for an aircraft design.
+
+    Overridden fields (from MP01-MP07) are used directly.
+    Non-overridden fields are estimated via the component build-up method.
+
+    All positions in mm (matching CHENG coordinate system).
+    All inertias in kg·m² (SI).
+    """
+
+    mass_g: float
+    """Total aircraft mass in grams."""
+
+    cg_x_mm: float
+    """CG longitudinal position from nose (mm)."""
+
+    cg_z_mm: float
+    """CG vertical offset (mm, positive = up from wing plane)."""
+
+    cg_y_mm: float
+    """CG lateral offset (mm, positive = starboard). Nominally 0 for symmetric designs."""
+
+    ixx_kg_m2: float
+    """Roll moment of inertia about body X-axis (kg·m²)."""
+
+    iyy_kg_m2: float
+    """Pitch moment of inertia about body Y-axis (kg·m²). Typically > Ixx."""
+
+    izz_kg_m2: float
+    """Yaw moment of inertia about body Z-axis (kg·m²). Typically largest."""
+
+    ixx_estimated: bool
+    """True when Ixx is a geometric estimate; False when MP05 override is active."""
+
+    iyy_estimated: bool
+    """True when Iyy is a geometric estimate; False when MP06 override is active."""
+
+    izz_estimated: bool
+    """True when Izz is a geometric estimate; False when MP07 override is active."""
+
+
+# ---------------------------------------------------------------------------
+# Component build-up inertia estimation
+# ---------------------------------------------------------------------------
+
+def _get(derived: "Union[DerivedValues, dict]", key: str, default: float = 0.0) -> float:
+    """Get a value from a DerivedValues object or dict."""
+    if isinstance(derived, dict):
+        return float(derived.get(key, default))
+    return float(getattr(derived, key, default))
+
+
+def estimate_inertia(
+    design: "AircraftDesign",
+    derived: "Union[DerivedValues, dict]",
+) -> tuple[float, float, float]:
+    """Estimate moments of inertia via a component build-up method.
+
+    Uses simplified geometric shapes for each major component:
+    - Wing: thin uniform plate (each half, reflected)
+    - Fuselage: solid cylinder approximation
+    - Tail: thin uniform plate at distance l_t from CG
+    - Motor: point mass at nose
+
+    Args:
+        design: Aircraft design parameters.
+        derived: Backend-computed derived values (used for weight estimates).
+
+    Returns:
+        (Ixx, Iyy, Izz) moments of inertia in kg·m².
+
+    Physical constraints satisfied:
+        - Ixx < Iyy < Izz for conventional layouts (roll < pitch < yaw)
+        - All values positive
+    """
+    # ── Component masses (SI) ──────────────────────────────────────────────
+    # Use derived.weight_* for geometry-based estimates.
+    m_wing_kg = _get(derived, "weight_wing_g") / 1000.0
+    m_tail_kg = _get(derived, "weight_tail_g") / 1000.0
+    m_fus_kg = _get(derived, "weight_fuselage_g") / 1000.0
+    m_motor_kg = design.motor_weight_g / 1000.0
+    m_battery_kg = design.battery_weight_g / 1000.0
+
+    # Total for distribution of electronics
+    m_avionics_kg = max(0.0, (_get(derived, "weight_total_g") / 1000.0)
+                        - m_wing_kg - m_tail_kg - m_fus_kg
+                        - m_motor_kg - m_battery_kg)
+
+    # ── Key geometric dimensions (SI, metres) ─────────────────────────────
+    b_m = design.wing_span / 1000.0          # Full span [m]
+    b_half_m = b_m / 2.0                     # Semi-span [m]
+    c_m = design.wing_chord / 1000.0         # Root chord [m]
+    L_m = design.fuselage_length / 1000.0    # Fuselage length [m]
+    l_t_m = design.tail_arm / 1000.0         # Tail moment arm [m]
+
+    # Fuselage cross-section radius estimate
+    if design.fuselage_preset == "Pod":
+        r_fus_m = (design.wing_chord * 0.45) / 2000.0
+    elif design.fuselage_preset == "Blended-Wing-Body":
+        r_fus_m = (design.wing_chord * 0.35) / 2000.0
+    else:  # Conventional
+        r_fus_m = (design.wing_chord * 0.35) / 2000.0
+
+    # Motor position (nose region, fraction of fuselage length)
+    x_motor_m = L_m * 0.05  # ~5% from nose for tractor configs
+
+    # Battery position
+    x_battery_m = L_m * design.battery_position_frac
+
+    # CG position from derived
+    estimated_cg_mm = _get(derived, "estimated_cg_mm", L_m * 0.30 * 1000.0)
+
+    # ── Wing contribution ─────────────────────────────────────────────────
+    # Model each half as a slender rod with distributed mass along the span.
+    # For a uniform rod of mass m and length L: I_end = (1/3)*m*L²
+    # For span axis: I_xx ~ sum of thin disk slices
+
+    # Roll (Ixx): wing mass distributed along span
+    # Both halves: I_roll = 2 * (1/3) * (m_wing/2) * b_half² = (1/3)*m_wing*b_half²
+    I_wing_roll = (1.0 / 3.0) * m_wing_kg * b_half_m ** 2
+
+    # Pitch (Iyy): wing mass distributed along chord direction
+    # Model as thin plate: I_pitch = (1/12)*m*c²
+    I_wing_pitch = (1.0 / 12.0) * m_wing_kg * c_m ** 2
+
+    # Yaw (Izz): perpendicular to wing plane (combines span and chord contributions)
+    I_wing_yaw = I_wing_roll + I_wing_pitch
+
+    # ── Fuselage contribution ─────────────────────────────────────────────
+    # Solid cylinder approximation: mass m, length L, radius r
+    # I_roll (about long axis) = (1/2) * m * r²
+    # I_pitch (about lateral axis) = (1/12) * m * (L² + 3r²)
+    # Note: for a fuselage, the long axis is X, lateral is Y
+    I_fus_roll = 0.5 * m_fus_kg * r_fus_m ** 2  # Ixx for fuselage
+    I_fus_pitch = (1.0 / 12.0) * m_fus_kg * (L_m ** 2 + 3.0 * r_fus_m ** 2)  # Iyy
+
+    # ── Tail contribution ─────────────────────────────────────────────────
+    # Point mass at distance l_t from CG adds m*l_t² to Iyy and Izz
+    # (the tail is behind the CG, contributes to pitch and yaw inertia)
+    I_tail_pitch = m_tail_kg * l_t_m ** 2  # added to Iyy
+    I_tail_yaw = m_tail_kg * l_t_m ** 2    # added to Izz
+
+    # ── Motor contribution ────────────────────────────────────────────────
+    # Point mass near nose, at distance x_motor from CG
+    # CG is roughly at 30% of fuselage length
+    cg_x_m = estimated_cg_mm / 1000.0
+    x_motor_from_cg = abs(x_motor_m - cg_x_m)
+    I_motor_pitch = m_motor_kg * x_motor_from_cg ** 2  # added to Iyy
+
+    # ── Battery contribution ──────────────────────────────────────────────
+    x_battery_from_cg = abs(x_battery_m - cg_x_m)
+    I_battery_pitch = m_battery_kg * x_battery_from_cg ** 2
+
+    # ── Assemble totals ───────────────────────────────────────────────────
+    ixx = I_wing_roll + I_fus_roll
+    iyy = I_wing_pitch + I_fus_pitch + I_tail_pitch + I_motor_pitch + I_battery_pitch
+    izz = I_wing_yaw + I_fus_pitch + I_tail_yaw + I_motor_pitch + I_battery_pitch
+
+    # Ensure minimum plausible values and physical ordering constraint
+    # (small floating point errors can break Ixx < Iyy < Izz in degenerate cases)
+    ixx = max(ixx, 1e-6)
+    iyy = max(iyy, ixx * 1.01)  # Iyy > Ixx for typical configs
+    izz = max(izz, iyy * 1.01)  # Izz > Iyy for typical configs
+
+    return ixx, iyy, izz
+
+
+# ---------------------------------------------------------------------------
+# Mass properties resolver (entry point)
+# ---------------------------------------------------------------------------
+
+def resolve_mass_properties(
+    design: "AircraftDesign",
+    derived: "Union[DerivedValues, dict]",
+) -> MassProperties:
+    """Resolve mass properties, applying MP01-MP07 overrides where set.
+
+    Each override field is applied independently: if MP05 (Ixx override) is
+    set but MP06 (Iyy) is not, Ixx uses the override and Iyy is estimated.
+
+    Args:
+        design: Aircraft design (may have mass property override fields set).
+        derived: Computed derived values (provides weight and CG estimates).
+
+    Returns:
+        MassProperties with fully resolved values.
+    """
+    # ── Mass (MP01) ────────────────────────────────────────────────────────
+    if design.mass_total_override_g is not None:
+        mass_g = float(design.mass_total_override_g)
+    else:
+        mass_g = _get(derived, "weight_total_g")
+
+    # ── CG position (MP02-MP04) ────────────────────────────────────────────
+    if design.cg_override_x_mm is not None:
+        cg_x_mm = float(design.cg_override_x_mm)
+    else:
+        cg_x_mm = _get(derived, "estimated_cg_mm")
+
+    if design.cg_override_z_mm is not None:
+        cg_z_mm = float(design.cg_override_z_mm)
+    else:
+        cg_z_mm = 0.0
+
+    if design.cg_override_y_mm is not None:
+        cg_y_mm = float(design.cg_override_y_mm)
+    else:
+        cg_y_mm = 0.0
+
+    # ── Moments of inertia (MP05-MP07) ────────────────────────────────────
+    # Always compute the estimate so we can fall back per-axis.
+    ixx_est, iyy_est, izz_est = estimate_inertia(design, derived)
+
+    if design.ixx_override_kg_m2 is not None:
+        ixx = float(design.ixx_override_kg_m2)
+        ixx_estimated = False
+    else:
+        ixx = ixx_est
+        ixx_estimated = True
+
+    if design.iyy_override_kg_m2 is not None:
+        iyy = float(design.iyy_override_kg_m2)
+        iyy_estimated = False
+    else:
+        iyy = iyy_est
+        iyy_estimated = True
+
+    if design.izz_override_kg_m2 is not None:
+        izz = float(design.izz_override_kg_m2)
+        izz_estimated = False
+    else:
+        izz = izz_est
+        izz_estimated = True
+
+    return MassProperties(
+        mass_g=mass_g,
+        cg_x_mm=cg_x_mm,
+        cg_z_mm=cg_z_mm,
+        cg_y_mm=cg_y_mm,
+        ixx_kg_m2=ixx,
+        iyy_kg_m2=iyy,
+        izz_kg_m2=izz,
+        ixx_estimated=ixx_estimated,
+        iyy_estimated=iyy_estimated,
+        izz_estimated=izz_estimated,
+    )

--- a/backend/models.py
+++ b/backend/models.py
@@ -287,6 +287,76 @@ class AircraftDesign(CamelModel):
 
 
 # ---------------------------------------------------------------------------
+# Dynamic Stability Result — computed by DATCOM pipeline, read-only
+# ---------------------------------------------------------------------------
+
+class DynamicStabilityResult(CamelModel):
+    """DATCOM-computed dynamic stability mode characteristics.
+
+    Serialized to frontend as camelCase via alias_generator=to_camel.
+    All frequencies in rad/s; periods and time constants in seconds.
+    """
+
+    # Longitudinal modes
+    sp_omega_n: float = 0.0
+    """Short-period natural frequency (rad/s)."""
+
+    sp_zeta: float = 0.0
+    """Short-period damping ratio."""
+
+    sp_period_s: float = 0.0
+    """Short-period period (s)."""
+
+    phugoid_omega_n: float = 0.0
+    """Phugoid natural frequency (rad/s)."""
+
+    phugoid_zeta: float = 0.0
+    """Phugoid damping ratio."""
+
+    phugoid_period_s: float = 0.0
+    """Phugoid period (s)."""
+
+    # Lateral/directional modes
+    dr_omega_n: float = 0.0
+    """Dutch roll natural frequency (rad/s)."""
+
+    dr_zeta: float = 0.0
+    """Dutch roll damping ratio."""
+
+    dr_period_s: float = 0.0
+    """Dutch roll period (s)."""
+
+    roll_tau_s: float = 0.0
+    """Roll mode time constant (s)."""
+
+    spiral_tau_s: float = 0.0
+    """Spiral mode time constant (s). Negative = divergent."""
+
+    spiral_t2_s: float = 0.0
+    """Spiral time-to-double (s). Large positive = effectively stable."""
+
+    # Stability derivatives (passthrough for frontend display)
+    cl_alpha: float = 0.0
+    cd_alpha: float = 0.0
+    cm_alpha: float = 0.0
+    cl_q: float = 0.0
+    cm_q: float = 0.0
+    cl_alphadot: float = 0.0
+    cm_alphadot: float = 0.0
+    cy_beta: float = 0.0
+    cl_beta: float = 0.0
+    cn_beta: float = 0.0
+    cy_p: float = 0.0
+    cl_p: float = 0.0
+    cn_p: float = 0.0
+    cy_r: float = 0.0
+    cl_r: float = 0.0
+    cn_r: float = 0.0
+
+    derivatives_estimated: bool = True
+
+
+# ---------------------------------------------------------------------------
 # Derived Values — computed by geometry engine, read-only
 # ---------------------------------------------------------------------------
 
@@ -317,6 +387,10 @@ class DerivedValues(CamelModel):
     tail_volume_h: float = 0.0
     tail_volume_v: float = 0.0
     wing_loading_g_dm2: float = 0.0
+
+    # Dynamic stability fields (v1.2) — computed by DATCOM pipeline.
+    # None when DATCOM computation is unavailable or fails.
+    dynamic_stability: Optional[DynamicStabilityResult] = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/models.py
+++ b/backend/models.py
@@ -224,6 +224,67 @@ class AircraftDesign(CamelModel):
     tail_wheel_diameter: float = Field(default=12.0, ge=5.0, le=40.0)   # mm
     tail_gear_position: float = Field(default=92.0, ge=85.0, le=98.0)   # % fuselage length
 
+    # ── Mass Properties Override (MP01–MP07) ─────────────────────────────────
+    # Optional measured values that replace CHENG's geometric estimates when set.
+    # All default to None for backward compatibility with existing designs.
+    mass_total_override_g: Optional[float] = Field(
+        default=None,
+        ge=50.0,
+        le=10000.0,
+        description="MP01: Measured total aircraft mass in grams. Overrides weight_total_g.",
+    )
+    cg_override_x_mm: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=2000.0,
+        description="MP02: Measured CG position along fuselage longitudinal axis (mm from nose).",
+    )
+    cg_override_z_mm: Optional[float] = Field(
+        default=None,
+        ge=-50.0,
+        le=100.0,
+        description="MP03: Measured CG offset in vertical direction (mm, positive up).",
+    )
+    cg_override_y_mm: Optional[float] = Field(
+        default=None,
+        ge=-100.0,
+        le=100.0,
+        description="MP04: Measured CG offset in lateral direction (mm, positive starboard).",
+    )
+    ixx_override_kg_m2: Optional[float] = Field(
+        default=None,
+        ge=0.0001,
+        le=10.0,
+        description="MP05: Measured roll moment of inertia (kg·m²).",
+    )
+    iyy_override_kg_m2: Optional[float] = Field(
+        default=None,
+        ge=0.0001,
+        le=10.0,
+        description="MP06: Measured pitch moment of inertia (kg·m²).",
+    )
+    izz_override_kg_m2: Optional[float] = Field(
+        default=None,
+        ge=0.0001,
+        le=10.0,
+        description="MP07: Measured yaw moment of inertia (kg·m²).",
+    )
+
+    # ── Flight Condition (FC01–FC02) ─────────────────────────────────────────
+    # Used by the DATCOM dynamic stability analysis. Default 50 m/s / sea level.
+    flight_speed_ms: float = Field(
+        default=50.0,
+        ge=10.0,
+        le=100.0,
+        description="FC01: Cruise airspeed for dynamic stability analysis (m/s).",
+    )
+    flight_altitude_m: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=3000.0,
+        description="FC02: Flight altitude for ISA atmosphere model (m above MSL).",
+    )
+
 
 # ---------------------------------------------------------------------------
 # Derived Values — computed by geometry engine, read-only

--- a/backend/routes/generate.py
+++ b/backend/routes/generate.py
@@ -34,7 +34,8 @@ async def generate(design: AircraftDesign) -> GenerationResult:
     try:
         derived_dict = compute_derived_values(design)
         derived = DerivedValues(**derived_dict)
-        warnings = compute_warnings(design)
+        # Pass derived_dict so V36-V48 dynamic/mass-property warnings fire.
+        warnings = compute_warnings(design, derived_dict)
 
         return GenerationResult(derived=derived, warnings=warnings)
 

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -262,7 +262,8 @@ async def preview_websocket(ws: WebSocket) -> None:
                 derived = DerivedValues(**derived_dict)
 
                 # Compute warnings (canonical module)
-                warnings_list = compute_warnings(latest)
+                # Pass derived_dict so V36-V48 dynamic/mass-property warnings fire.
+                warnings_list = compute_warnings(latest, derived_dict)
 
                 # Generate geometry in thread pool with limiter.
                 # abandon_on_cancel=False ensures the thread releases

--- a/frontend/src/components/DynamicStabilitySummaryCard.tsx
+++ b/frontend/src/components/DynamicStabilitySummaryCard.tsx
@@ -1,0 +1,154 @@
+// ============================================================================
+// CHENG — Dynamic Stability Summary Card
+// Compact in-viewport card showing at-a-glance quality dots for 3 key modes.
+// Fixed bottom-left of viewport. Clicking opens the Stability Overlay on the
+// Dynamic Stability tab. Hidden when overlay is open or dynamicStability is null.
+// Issue #359
+// ============================================================================
+
+import React from 'react';
+import { useDesignStore } from '../store/designStore';
+import {
+  classifyShortPeriod,
+  classifyPhugoid,
+  classifyDutchRoll,
+  type ModeQuality,
+} from '../lib/dynamicStabilityAnalyzer';
+
+// ---------------------------------------------------------------------------
+// Quality dot — colored circle
+// ---------------------------------------------------------------------------
+
+interface QualityDotProps {
+  quality: ModeQuality;
+}
+
+function QualityDot({ quality }: QualityDotProps): React.JSX.Element {
+  const colorMap: Record<ModeQuality, string> = {
+    good:       'bg-green-400',
+    acceptable: 'bg-amber-400',
+    poor:       'bg-red-400',
+    unknown:    'bg-zinc-500',
+  };
+  return (
+    <span
+      className={`w-2 h-2 rounded-full shrink-0 ${colorMap[quality]}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface DynamicStabilitySummaryCardProps {
+  /** Whether the stability overlay is currently open (card hides itself). */
+  overlayOpen: boolean;
+  /** Called when the user clicks the card — parent should open overlay. */
+  onOpen: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Compact summary card displayed at the bottom-left of the 3D viewport.
+ *
+ * Shows three rows: Short-Period, Phugoid, Dutch Roll — each with a
+ * colored quality dot (green/amber/red) derived from the DATCOM results.
+ *
+ * Hidden when:
+ * - dynamicStability is null/undefined (no DATCOM results yet)
+ * - The stability overlay is open (avoids visual redundancy)
+ *
+ * Clicking the card triggers onOpen() which should open the stability overlay
+ * and switch to the Dynamic Stability tab.
+ */
+export function DynamicStabilitySummaryCard({
+  overlayOpen,
+  onOpen,
+}: DynamicStabilitySummaryCardProps): React.JSX.Element | null {
+  const derived = useDesignStore((s) => s.derived);
+  const ds = derived?.dynamicStability;
+
+  // Hide when no data or overlay already open
+  if (!ds || overlayOpen) {
+    return null;
+  }
+
+  const spQuality  = classifyShortPeriod(ds.spZeta, ds.spOmegaN);
+  const phQuality  = classifyPhugoid(ds.phugoidZeta);
+  const drQuality  = classifyDutchRoll(ds.drZeta, ds.drOmegaN);
+
+  // Overall quality: worst of the three
+  const qualityRank: Record<ModeQuality, number> = { good: 0, acceptable: 1, poor: 2, unknown: 3 };
+  const overallRank = Math.max(qualityRank[spQuality], qualityRank[phQuality], qualityRank[drQuality]);
+  const overallLabels = ['Good', 'Acceptable', 'Poor', 'Unknown'];
+  const overallLabel = overallLabels[overallRank] ?? 'Unknown';
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label={`Dynamic stability summary: ${overallLabel}. Click to open stability analysis.`}
+      className={[
+        'fixed bottom-4 left-4 z-40',
+        'bg-zinc-900/95 border border-zinc-700/80 rounded-lg shadow-lg shadow-black/40',
+        'px-3 py-2 text-left',
+        'hover:border-zinc-500 hover:bg-zinc-800/95',
+        'focus:outline-none focus:ring-1 focus:ring-sky-500',
+        'transition-colors cursor-pointer',
+        'select-none',
+      ].join(' ')}
+    >
+      {/* Header */}
+      <div className="text-[9px] font-semibold text-zinc-500 uppercase tracking-wider mb-1.5">
+        Stability
+      </div>
+
+      {/* Mode rows */}
+      <div className="flex flex-col gap-1">
+        <ModeRow label="Short-Period" quality={spQuality} />
+        <ModeRow label="Phugoid"      quality={phQuality} />
+        <ModeRow label="Dutch Roll"   quality={drQuality} />
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mode row helper
+// ---------------------------------------------------------------------------
+
+interface ModeRowProps {
+  label: string;
+  quality: ModeQuality;
+}
+
+function ModeRow({ label, quality }: ModeRowProps): React.JSX.Element {
+  const qualityLabels: Record<ModeQuality, string> = {
+    good:       'Good',
+    acceptable: 'OK',
+    poor:       'Poor',
+    unknown:    '—',
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <QualityDot quality={quality} />
+      <span className="text-[10px] text-zinc-400 flex-1 leading-none">{label}</span>
+      <span
+        className={[
+          'text-[10px] font-medium leading-none',
+          quality === 'good'       ? 'text-green-400' :
+          quality === 'acceptable' ? 'text-amber-400' :
+          quality === 'poor'       ? 'text-red-400'   :
+          'text-zinc-500',
+        ].join(' ')}
+      >
+        {qualityLabels[quality]}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/StabilityOverlay.tsx
+++ b/frontend/src/components/StabilityOverlay.tsx
@@ -1,12 +1,18 @@
 // ============================================================================
-// CHENG — Stability Overlay
-// Floating panel wrapper that positions StabilityPanel as a fixed card
-// overlaying the 3D viewport. Toggled from the Toolbar.
-// Issue #317
+// CHENG — Stability Analysis Overlay
+// Floating panel wrapper with three tabs: Static Stability, Mass Properties,
+// Dynamic Stability. Toggled from the Toolbar.
+// Issue #355
 // ============================================================================
 
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { StabilityPanel } from './panels/StabilityPanel';
+import { MassPropertiesTab } from './stability/MassPropertiesTab';
+import { DynamicStabilityTab } from './stability/DynamicStabilityTab';
+
+// ─── Tab type ─────────────────────────────────────────────────────────────────
+
+export type StabilityTab = 'static' | 'mass' | 'dynamic';
 
 // ─── Props ───────────────────────────────────────────────────────────────────
 
@@ -15,17 +21,29 @@ interface StabilityOverlayProps {
   onClose: () => void;
   /** Ref to the toolbar's Toggle Plots button, so focus can be restored on close. */
   toggleButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  /** Initial tab to show when the overlay opens (default: 'static'). */
+  initialTab?: StabilityTab;
+  /** Called when the active tab changes, so parent can track it. */
+  onTabChange?: (tab: StabilityTab) => void;
 }
+
+// ─── Tab definitions ──────────────────────────────────────────────────────────
+
+const TABS: { id: StabilityTab; label: string }[] = [
+  { id: 'static',  label: 'Static' },
+  { id: 'mass',    label: 'Mass' },
+  { id: 'dynamic', label: 'Dynamic' },
+];
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
- * Floating panel overlay for the Stability Plots feature.
+ * Floating panel overlay for the Stability Analysis feature.
  *
  * Positioning: `fixed top-14 right-4` — just below the 40px toolbar with a
  * visible gap. `z-40` sits above the 3D canvas but below modal dialogs (`z-50`).
  *
- * Width: `w-72` (288px) — readable gauges without obscuring the left sidebar.
+ * Width: `w-80` (320px) — readable gauges without obscuring the left sidebar.
  *
  * Scrollable: `max-h-[calc(100vh-8rem)]` prevents overflow below the viewport.
  *
@@ -37,8 +55,11 @@ interface StabilityOverlayProps {
 export function StabilityOverlay({
   onClose,
   toggleButtonRef,
+  initialTab = 'static',
+  onTabChange,
 }: StabilityOverlayProps): React.JSX.Element {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [activeTab, setActiveTab] = useState<StabilityTab>(initialTab);
 
   // Close handler: dismiss overlay and restore focus to the toolbar toggle button.
   const handleClose = useCallback(() => {
@@ -63,25 +84,35 @@ export function StabilityOverlay({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [handleClose]);
 
+  // Sync initialTab if parent changes it after mount (e.g. summary card click).
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  const handleTabChange = (tab: StabilityTab) => {
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
+
   return (
     <div
       id="stability-overlay"
       role="dialog"
-      aria-label="Stability plots"
+      aria-label="Stability analysis"
       aria-modal="false"
-      className="fixed top-14 right-4 z-40 w-72 bg-zinc-900 border border-zinc-700
+      className="fixed top-14 right-4 z-40 w-80 bg-zinc-900 border border-zinc-700
         rounded-lg shadow-2xl shadow-black/60 flex flex-col"
     >
       {/* Header bar */}
       <div className="flex items-center justify-between px-3 py-2
         border-b border-zinc-800 flex-shrink-0">
         <span className="text-xs font-semibold text-zinc-300">
-          Stability Plots
+          Stability Analysis
         </span>
         <button
           ref={closeButtonRef}
           onClick={handleClose}
-          aria-label="Close stability plots"
+          aria-label="Close stability analysis"
           className="w-5 h-5 flex items-center justify-center text-zinc-500
             rounded hover:bg-zinc-700 hover:text-zinc-200
             focus:outline-none focus:ring-1 focus:ring-zinc-600 text-sm leading-none"
@@ -91,9 +122,43 @@ export function StabilityOverlay({
         </button>
       </div>
 
+      {/* Tab bar */}
+      <div
+        role="tablist"
+        aria-label="Stability analysis tabs"
+        className="flex border-b border-zinc-800 flex-shrink-0"
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`stability-tab-panel-${tab.id}`}
+            id={`stability-tab-${tab.id}`}
+            onClick={() => handleTabChange(tab.id)}
+            className={[
+              'flex-1 px-2 py-1.5 text-xs font-medium transition-colors',
+              'focus:outline-none focus:ring-1 focus:ring-inset focus:ring-zinc-600',
+              activeTab === tab.id
+                ? 'text-sky-400 border-b-2 border-sky-500 bg-zinc-800/50'
+                : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/30',
+            ].join(' ')}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
       {/* Panel body — scrollable if content overflows viewport */}
-      <div className="overflow-y-auto flex-1 min-h-0 max-h-[calc(100vh-8rem)]">
-        <StabilityPanel />
+      <div
+        id={`stability-tab-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`stability-tab-${activeTab}`}
+        className="overflow-y-auto flex-1 min-h-0 max-h-[calc(100vh-9rem)]"
+      >
+        {activeTab === 'static'  && <StabilityPanel />}
+        {activeTab === 'mass'    && <MassPropertiesTab />}
+        {activeTab === 'dynamic' && <DynamicStabilityTab />}
       </div>
     </div>
   );

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -18,6 +18,8 @@ import { ModeBadge } from './ModeBadge';
 import { useModeInfo } from '../hooks/useModeInfo';
 import { UnitToggle } from './UnitToggle';
 import { StabilityOverlay } from './StabilityOverlay';
+import type { StabilityTab } from './StabilityOverlay';
+import { DynamicStabilitySummaryCard } from './DynamicStabilitySummaryCard';
 import { PRESET_DESCRIPTIONS } from '../lib/presets';
 import {
   listCustomPresets,
@@ -520,6 +522,7 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
   const [loadDialogOpen, setLoadDialogOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [plotsOpen, setPlotsOpen] = useState(false);
+  const [plotsInitialTab, setPlotsInitialTab] = useState<StabilityTab>('static');
   const [isEditingName, setIsEditingName] = useState(false);
   const togglePlotsButtonRef = useRef<HTMLButtonElement>(null);
   const [editNameValue, setEditNameValue] = useState(designName);
@@ -795,7 +798,10 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
         {/* Toggle Plots button (#317) — opens/closes the stability plots overlay */}
         <button
           ref={togglePlotsButtonRef}
-          onClick={() => setPlotsOpen((v) => !v)}
+          onClick={() => {
+            if (!plotsOpen) setPlotsInitialTab('static');
+            setPlotsOpen((v) => !v);
+          }}
           aria-pressed={plotsOpen}
           aria-controls="stability-overlay"
           aria-label={plotsOpen ? 'Hide stability plots' : 'Show stability plots'}
@@ -1025,8 +1031,18 @@ export function Toolbar({ onOpenExport }: ToolbarProps): React.JSX.Element {
         <StabilityOverlay
           onClose={() => setPlotsOpen(false)}
           toggleButtonRef={togglePlotsButtonRef}
+          initialTab={plotsInitialTab}
         />
       )}
+
+      {/* Dynamic Stability Summary Card (#359) — compact in-viewport status */}
+      <DynamicStabilitySummaryCard
+        overlayOpen={plotsOpen}
+        onOpen={() => {
+          setPlotsInitialTab('dynamic');
+          setPlotsOpen(true);
+        }}
+      />
 
       {/* Load Design Dialog (#93) */}
       <LoadDesignDialog open={loadDialogOpen} onOpenChange={setLoadDialogOpen} />

--- a/frontend/src/components/stability/DynamicStabilityTab.tsx
+++ b/frontend/src/components/stability/DynamicStabilityTab.tsx
@@ -1,0 +1,20 @@
+// ============================================================================
+// CHENG — Dynamic Stability Tab (stub)
+// Placeholder for the Dynamic Stability tab in the Stability Analysis overlay.
+// Full implementation will follow in a separate issue.
+// Issue #355
+// ============================================================================
+
+import React from 'react';
+
+/**
+ * Dynamic Stability Tab — stub placeholder.
+ * Full implementation in issue #358.
+ */
+export function DynamicStabilityTab(): React.JSX.Element {
+  return (
+    <div className="p-4 text-xs text-zinc-400">
+      Dynamic Stability coming soon
+    </div>
+  );
+}

--- a/frontend/src/components/stability/DynamicStabilityTab.tsx
+++ b/frontend/src/components/stability/DynamicStabilityTab.tsx
@@ -1,20 +1,238 @@
 // ============================================================================
-// CHENG — Dynamic Stability Tab (stub)
-// Placeholder for the Dynamic Stability tab in the Stability Analysis overlay.
-// Full implementation will follow in a separate issue.
-// Issue #355
+// CHENG — Dynamic Stability Tab
+// Displays DATCOM dynamic mode analysis results with quality classification.
+// Issue #358
 // ============================================================================
 
 import React from 'react';
+import { useDesignStore } from '../../store/designStore';
+import {
+  classifyShortPeriod,
+  classifyPhugoid,
+  classifyDutchRoll,
+  classifyRollMode,
+  classifySpiralMode,
+  type ModeQuality,
+} from '../../lib/dynamicStabilityAnalyzer';
+import type { DynamicStabilityResult } from '../../types/design';
+
+// ---------------------------------------------------------------------------
+// Quality badge — color-coded chip
+// ---------------------------------------------------------------------------
+
+interface QualityBadgeProps {
+  quality: ModeQuality;
+}
+
+function QualityBadge({ quality }: QualityBadgeProps): React.JSX.Element {
+  const map: Record<ModeQuality, { label: string; cls: string }> = {
+    good:       { label: 'Good',       cls: 'bg-green-900/40 text-green-400 border-green-700/40' },
+    acceptable: { label: 'Acceptable', cls: 'bg-amber-900/30 text-amber-400 border-amber-700/40' },
+    poor:       { label: 'Poor',       cls: 'bg-red-900/40 text-red-400 border-red-700/40' },
+    unknown:    { label: 'Unknown',    cls: 'bg-zinc-800/40 text-zinc-500 border-zinc-700/40' },
+  };
+  const { label, cls } = map[quality];
+  return (
+    <span
+      className={`text-[10px] px-1.5 py-0.5 rounded border font-medium shrink-0 ${cls}`}
+      aria-label={`Quality: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mode row — label + value + quality badge
+// ---------------------------------------------------------------------------
+
+interface ModeRowProps {
+  label: string;
+  value: string;
+  quality: ModeQuality;
+  title?: string;
+}
+
+function ModeRow({ label, value, quality, title }: ModeRowProps): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-between py-0.5 gap-1" title={title}>
+      <span className="text-xs text-zinc-400 shrink-0 min-w-0 flex-1">{label}</span>
+      <span className="text-xs text-zinc-300 tabular-nums mx-1 shrink-0">{value}</span>
+      <QualityBadge quality={quality} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Derivative row — compact label + value
+// ---------------------------------------------------------------------------
+
+interface DerivRowProps {
+  label: string;
+  value: number;
+  title?: string;
+}
+
+function DerivRow({ label, value, title }: DerivRowProps): React.JSX.Element {
+  const formatted = Number.isFinite(value)
+    ? value.toFixed(3)
+    : value > 0 ? '+\u221e' : '\u2212\u221e';
+
+  return (
+    <div className="flex items-center justify-between py-0.5" title={title}>
+      <span className="text-xs text-zinc-500 font-mono">{label}</span>
+      <span className="text-xs text-zinc-400 tabular-nums">{formatted}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 mt-3 mb-1 pb-0.5 border-b border-zinc-700/50">
+      {children}
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Formatted period/tau helpers
+// ---------------------------------------------------------------------------
+
+function formatPeriod(periodS: number): string {
+  if (!Number.isFinite(periodS) || periodS <= 0) return 'aperiodic';
+  return `${periodS.toFixed(2)} s`;
+}
+
+function formatT2(t2S: number): string {
+  if (isNaN(t2S)) return '\u2014';
+  if (t2S === Infinity || t2S < 0) return 'stable';
+  return `${t2S.toFixed(1)} s`;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 /**
- * Dynamic Stability Tab — stub placeholder.
- * Full implementation in issue #358.
+ * Dynamic Stability Tab — shows DATCOM dynamic mode analysis results.
+ * Displays quality classifications (per MIL-F-8785C) and stability derivatives.
+ * Issue #358.
  */
 export function DynamicStabilityTab(): React.JSX.Element {
+  const derived = useDesignStore((s) => s.derived);
+  const ds: DynamicStabilityResult | null | undefined = derived?.dynamicStability;
+
+  // Loading / not-computed states
+  if (!derived) {
+    return (
+      <div className="p-4 text-xs text-zinc-500 text-center py-8">
+        Waiting for analysis data...
+      </div>
+    );
+  }
+
+  if (!ds) {
+    return (
+      <div className="p-4 space-y-2">
+        <p className="text-xs text-zinc-500 text-center py-4">
+          Dynamic stability analysis not yet available.
+        </p>
+        <p className="text-[11px] text-zinc-600 text-center">
+          Results will appear here once the backend DATCOM pipeline is integrated.
+        </p>
+      </div>
+    );
+  }
+
+  // Classify each mode using MIL-F-8785C boundaries
+  const spQuality     = classifyShortPeriod(ds.spZeta, ds.spOmegaN);
+  const phQuality     = classifyPhugoid(ds.phugoidZeta);
+  const drQuality     = classifyDutchRoll(ds.drZeta, ds.drOmegaN);
+  const rollQuality   = classifyRollMode(ds.rollTauS);
+  const spiralQuality = classifySpiralMode(ds.spiralT2S);
+
   return (
-    <div className="p-4 text-xs text-zinc-400">
-      Dynamic Stability coming soon
-    </div>
+    <section
+      role="region"
+      aria-label="Dynamic Stability Analysis"
+      className="p-4 overflow-y-auto"
+    >
+      {/* Longitudinal modes */}
+      <SectionHeader>Longitudinal Modes</SectionHeader>
+
+      <ModeRow
+        label="Short Period"
+        value={`\u03b6=${ds.spZeta.toFixed(2)}, \u03c9n=${ds.spOmegaN.toFixed(2)} rad/s`}
+        quality={spQuality}
+        title={`Short-period oscillation. T=${formatPeriod(ds.spPeriodS)}. Level 1: 0.35\u2264\u03b6\u22641.30, \u03c9n>1.0 rad/s.`}
+      />
+
+      <ModeRow
+        label="Phugoid"
+        value={`\u03b6=${ds.phugoidZeta.toFixed(3)}, \u03c9n=${ds.phugoidOmegaN.toFixed(3)} rad/s`}
+        quality={phQuality}
+        title={`Slow speed/pitch oscillation. T=${formatPeriod(ds.phugoidPeriodS)}. Level 1: \u03b6\u22650.04.`}
+      />
+
+      {/* Lateral modes */}
+      <SectionHeader>Lateral Modes</SectionHeader>
+
+      <ModeRow
+        label="Dutch Roll"
+        value={`\u03b6=${ds.drZeta.toFixed(2)}, \u03c9n=${ds.drOmegaN.toFixed(2)} rad/s`}
+        quality={drQuality}
+        title={`Dutch roll oscillation. T=${formatPeriod(ds.drPeriodS)}. Level 1: \u03b6\u22650.08, \u03c9n\u22650.4 rad/s.`}
+      />
+
+      <ModeRow
+        label="Roll Mode"
+        value={`\u03c4=${ds.rollTauS.toFixed(2)} s`}
+        quality={rollQuality}
+        title="Roll mode time constant. Level 1: \u03c4\u22640.5 s. Level 2: \u03c4\u22641.0 s."
+      />
+
+      <ModeRow
+        label="Spiral"
+        value={`t\u2082=${formatT2(ds.spiralT2S)}`}
+        quality={spiralQuality}
+        title="Spiral divergence doubling time. Level 1: t2\u226520 s or stable. Level 2: t2\u22658 s."
+      />
+
+      {/* Stability derivatives (collapsible) */}
+      <details className="group mt-2">
+        <summary className="text-xs font-medium text-zinc-400 cursor-pointer hover:text-zinc-200 select-none py-1">
+          Stability Derivatives
+          {ds.derivativesEstimated && (
+            <span className="ml-1.5 text-[10px] text-amber-500">(DATCOM estimate)</span>
+          )}
+        </summary>
+
+        <div className="mt-1">
+          <SectionHeader>Longitudinal</SectionHeader>
+          <DerivRow label="CL\u03b1"     value={ds.clAlpha}    title="Lift-curve slope dCL/d\u03b1 (per rad)" />
+          <DerivRow label="CD\u03b1"     value={ds.cdAlpha}    title="Drag-slope dCD/d\u03b1 (per rad)" />
+          <DerivRow label="Cm\u03b1"     value={ds.cmAlpha}    title="Pitch stiffness dCm/d\u03b1 (negative = stable)" />
+          <DerivRow label="CL\u1E51"     value={ds.clQ}        title="Lift due to pitch rate" />
+          <DerivRow label="Cm\u1E51"     value={ds.cmQ}        title="Pitch damping dCm/d(qc/2V) (negative = damped)" />
+          <DerivRow label="CL\u03b1\u0307" value={ds.clAlphadot} title="Lift due to \u03b1-dot" />
+          <DerivRow label="Cm\u03b1\u0307" value={ds.cmAlphadot} title="Pitch due to \u03b1-dot" />
+
+          <SectionHeader>Lateral</SectionHeader>
+          <DerivRow label="CY\u03b2" value={ds.cyBeta} title="Side force due to sideslip" />
+          <DerivRow label="Cl\u03b2" value={ds.clBeta} title="Roll due to sideslip (dihedral effect; negative = stable)" />
+          <DerivRow label="Cn\u03b2" value={ds.cnBeta} title="Yaw due to sideslip (weathercock; positive = stable)" />
+          <DerivRow label="CY\u1E55"  value={ds.cyP}   title="Side force due to roll rate" />
+          <DerivRow label="Cl\u1E55"  value={ds.clP}   title="Roll damping (negative = damped)" />
+          <DerivRow label="Cn\u1E55"  value={ds.cnP}   title="Adverse yaw due to roll rate" />
+          <DerivRow label="CY\u0159"  value={ds.cyR}   title="Side force due to yaw rate" />
+          <DerivRow label="Cl\u0159"  value={ds.clR}   title="Roll due to yaw rate" />
+          <DerivRow label="Cn\u0159"  value={ds.cnR}   title="Yaw damping (negative = damped)" />
+        </div>
+      </details>
+    </section>
   );
 }

--- a/frontend/src/components/stability/MassPropertiesTab.tsx
+++ b/frontend/src/components/stability/MassPropertiesTab.tsx
@@ -1,20 +1,377 @@
 // ============================================================================
-// CHENG — Mass Properties Tab (stub)
-// Placeholder for the Mass Properties tab in the Stability Analysis overlay.
-// Full implementation will follow in a separate issue.
-// Issue #355
+// CHENG — Mass Properties Tab
+// Displays mass/CG/inertia state and provides MP01-MP07 override inputs.
+// Issue #357
 // ============================================================================
 
-import React from 'react';
+import React, { useId } from 'react';
+import { useDesignStore } from '../../store/designStore';
+import type { AircraftDesign } from '../../types/design';
+
+// ---------------------------------------------------------------------------
+// Helper: small numeric override input
+// ---------------------------------------------------------------------------
+
+interface OverrideInputProps {
+  label: string;
+  unit: string;
+  value: number | null | undefined;
+  min: number;
+  max: number;
+  step: number;
+  decimals?: number;
+  placeholder: string;
+  title?: string;
+  onChange: (value: number | null) => void;
+}
+
+function OverrideInput({
+  label,
+  unit,
+  value,
+  min,
+  max,
+  step,
+  decimals = 2,
+  placeholder,
+  title,
+  onChange,
+}: OverrideInputProps): React.JSX.Element {
+  const labelId = useId();
+  const inputId = useId();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.trim();
+    if (raw === '') {
+      onChange(null);
+    } else {
+      const parsed = parseFloat(raw);
+      if (!isNaN(parsed)) onChange(parsed);
+    }
+  };
+
+  const displayValue = value != null ? value.toFixed(decimals) : '';
+
+  return (
+    <div className="mb-2" title={title}>
+      <label
+        id={labelId}
+        htmlFor={inputId}
+        className="block text-xs font-medium text-zinc-400 mb-0.5"
+      >
+        {label}
+        <span className="ml-1 text-zinc-500 font-normal">({unit})</span>
+      </label>
+      <input
+        id={inputId}
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={displayValue}
+        placeholder={placeholder}
+        aria-labelledby={labelId}
+        onChange={handleChange}
+        className="w-full px-2 py-1 text-xs text-zinc-200 bg-zinc-800
+          border border-zinc-700 rounded focus:outline-none
+          focus:border-blue-500 focus:ring-1 focus:ring-blue-500/30
+          placeholder:text-zinc-600"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: read-only value row with "Estimated" / "Measured" badge
+// ---------------------------------------------------------------------------
+
+interface ReadonlyRowProps {
+  label: string;
+  value: string;
+  badge: 'estimated' | 'measured' | 'default';
+  title?: string;
+}
+
+function ReadonlyRow({ label, value, badge, title }: ReadonlyRowProps): React.JSX.Element {
+  const badgeClass =
+    badge === 'measured'
+      ? 'bg-green-900/40 text-green-400 border-green-700/40'
+      : badge === 'estimated'
+      ? 'bg-amber-900/30 text-amber-400 border-amber-700/40'
+      : 'bg-zinc-800/40 text-zinc-500 border-zinc-700/40';
+
+  const badgeLabel =
+    badge === 'measured' ? 'Measured' : badge === 'estimated' ? 'Estimated' : 'Default';
+
+  return (
+    <div className="flex items-center justify-between py-0.5" title={title}>
+      <span className="text-xs text-zinc-400 shrink-0 mr-2">{label}</span>
+      <div className="flex items-center gap-1.5 min-w-0">
+        <span className="text-xs text-zinc-300 tabular-nums">{value}</span>
+        <span
+          className={`text-[10px] px-1 py-0.5 rounded border font-medium shrink-0 ${badgeClass}`}
+        >
+          {badgeLabel}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section divider
+// ---------------------------------------------------------------------------
+
+function SectionHeader({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <p className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500 mt-3 mb-1 pb-0.5 border-b border-zinc-700/50">
+      {children}
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 /**
- * Mass Properties Tab — stub placeholder.
- * Full implementation in issue #357.
+ * Mass Properties Tab — shows resolved mass, CG, and inertia state,
+ * and provides numeric override inputs for MP01-MP07.
  */
 export function MassPropertiesTab(): React.JSX.Element {
+  const design = useDesignStore((s) => s.design);
+  const derived = useDesignStore((s) => s.derived);
+  const setParam = useDesignStore((s) => s.setParam);
+
+  // Resolved display values
+  // We show design.massTotalOverrideG if set, else note it's estimated from geometry
+  const massBadge: 'measured' | 'estimated' =
+    design.massTotalOverrideG != null ? 'measured' : 'estimated';
+  const massDisplay =
+    design.massTotalOverrideG != null
+      ? `${design.massTotalOverrideG.toFixed(0)} g`
+      : 'geometric estimate';
+
+  const cgXBadge: 'measured' | 'estimated' =
+    design.cgOverrideXMm != null ? 'measured' : 'estimated';
+  const cgXDisplay =
+    design.cgOverrideXMm != null
+      ? `${design.cgOverrideXMm.toFixed(1)} mm`
+      : derived
+      ? `${derived.estimatedCgMm.toFixed(1)} mm`
+      : '—';
+
+  const cgZBadge: 'measured' | 'default' =
+    design.cgOverrideZMm != null ? 'measured' : 'default';
+  const cgZDisplay =
+    design.cgOverrideZMm != null ? `${design.cgOverrideZMm.toFixed(1)} mm` : '0.0 mm';
+
+  const cgYBadge: 'measured' | 'default' =
+    design.cgOverrideYMm != null ? 'measured' : 'default';
+  const cgYDisplay =
+    design.cgOverrideYMm != null ? `${design.cgOverrideYMm.toFixed(1)} mm` : '0.0 mm';
+
+  const ixxBadge: 'measured' | 'estimated' =
+    design.ixxOverrideKgM2 != null ? 'measured' : 'estimated';
+  const ixxDisplay =
+    design.ixxOverrideKgM2 != null ? `${design.ixxOverrideKgM2.toFixed(4)} kg·m²` : 'geometric estimate';
+
+  const iyyBadge: 'measured' | 'estimated' =
+    design.iyyOverrideKgM2 != null ? 'measured' : 'estimated';
+  const iyyDisplay =
+    design.iyyOverrideKgM2 != null ? `${design.iyyOverrideKgM2.toFixed(4)} kg·m²` : 'geometric estimate';
+
+  const izzBadge: 'measured' | 'estimated' =
+    design.izzOverrideKgM2 != null ? 'measured' : 'estimated';
+  const izzDisplay =
+    design.izzOverrideKgM2 != null ? `${design.izzOverrideKgM2.toFixed(4)} kg·m²` : 'geometric estimate';
+
+  function setMpParam<K extends keyof AircraftDesign>(key: K, val: AircraftDesign[K]) {
+    setParam(key, val, 'text');
+  }
+
   return (
-    <div className="p-4 text-xs text-zinc-400">
-      Mass Properties coming soon
-    </div>
+    <section
+      role="region"
+      aria-label="Mass Properties"
+      className="p-4 space-y-0.5 overflow-y-auto"
+    >
+      {/* Current resolved values */}
+      <SectionHeader>Resolved Values</SectionHeader>
+
+      <ReadonlyRow
+        label="Total Mass"
+        value={massDisplay}
+        badge={massBadge}
+        title="MP01: Total aircraft mass. Set an override below, or leave blank to use the geometric estimate."
+      />
+      <ReadonlyRow
+        label="CG (longitudinal)"
+        value={cgXDisplay}
+        badge={cgXBadge}
+        title="MP02: CG position along fuselage from nose. Set an override below, or leave blank to use 25% MAC estimate."
+      />
+      <ReadonlyRow
+        label="CG (vertical)"
+        value={cgZDisplay}
+        badge={cgZBadge}
+        title="MP03: CG vertical offset. Positive = above wing plane. Default = 0."
+      />
+      <ReadonlyRow
+        label="CG (lateral)"
+        value={cgYDisplay}
+        badge={cgYBadge}
+        title="MP04: CG lateral offset. Positive = starboard. Should be 0 for symmetric designs."
+      />
+      <ReadonlyRow
+        label="Ixx (roll)"
+        value={ixxDisplay}
+        badge={ixxBadge}
+        title="MP05: Roll moment of inertia. Estimated from wing span and mass distribution if not measured."
+      />
+      <ReadonlyRow
+        label="Iyy (pitch)"
+        value={iyyDisplay}
+        badge={iyyBadge}
+        title="MP06: Pitch moment of inertia. Typically larger than Ixx for conventional layouts."
+      />
+      <ReadonlyRow
+        label="Izz (yaw)"
+        value={izzDisplay}
+        badge={izzBadge}
+        title="MP07: Yaw moment of inertia. Typically largest for conventional layouts."
+      />
+
+      {/* Override inputs */}
+      <SectionHeader>Measured Overrides</SectionHeader>
+
+      <p className="text-[11px] text-zinc-500 mb-2">
+        Enter measured values to replace geometric estimates. Leave blank to use estimates.
+      </p>
+
+      <OverrideInput
+        label="MP01 — Total Mass"
+        unit="g"
+        value={design.massTotalOverrideG ?? null}
+        min={50}
+        max={10000}
+        step={1}
+        decimals={0}
+        placeholder="e.g. 850"
+        title="Measured total aircraft all-up weight in grams"
+        onChange={(v) => setMpParam('massTotalOverrideG', v as AircraftDesign['massTotalOverrideG'])}
+      />
+
+      <OverrideInput
+        label="MP02 — CG Longitudinal"
+        unit="mm from nose"
+        value={design.cgOverrideXMm ?? null}
+        min={0}
+        max={2000}
+        step={0.5}
+        decimals={1}
+        placeholder="e.g. 340"
+        title="Measured CG position along fuselage axis from nose datum"
+        onChange={(v) => setMpParam('cgOverrideXMm', v as AircraftDesign['cgOverrideXMm'])}
+      />
+
+      <OverrideInput
+        label="MP03 — CG Vertical"
+        unit="mm (+ = up)"
+        value={design.cgOverrideZMm ?? null}
+        min={-50}
+        max={100}
+        step={0.5}
+        decimals={1}
+        placeholder="e.g. 0"
+        title="Measured CG vertical offset above/below wing plane"
+        onChange={(v) => setMpParam('cgOverrideZMm', v as AircraftDesign['cgOverrideZMm'])}
+      />
+
+      <OverrideInput
+        label="MP04 — CG Lateral"
+        unit="mm (+ = starboard)"
+        value={design.cgOverrideYMm ?? null}
+        min={-100}
+        max={100}
+        step={0.5}
+        decimals={1}
+        placeholder="e.g. 0"
+        title="Measured CG lateral offset. Should be ~0 for symmetric designs."
+        onChange={(v) => setMpParam('cgOverrideYMm', v as AircraftDesign['cgOverrideYMm'])}
+      />
+
+      <OverrideInput
+        label="MP05 — Ixx (roll)"
+        unit="kg·m²"
+        value={design.ixxOverrideKgM2 ?? null}
+        min={0.0001}
+        max={10}
+        step={0.0001}
+        decimals={4}
+        placeholder="e.g. 0.0150"
+        title="Measured roll moment of inertia. Use a bifilar pendulum or swing test."
+        onChange={(v) => setMpParam('ixxOverrideKgM2', v as AircraftDesign['ixxOverrideKgM2'])}
+      />
+
+      <OverrideInput
+        label="MP06 — Iyy (pitch)"
+        unit="kg·m²"
+        value={design.iyyOverrideKgM2 ?? null}
+        min={0.0001}
+        max={10}
+        step={0.0001}
+        decimals={4}
+        placeholder="e.g. 0.0320"
+        title="Measured pitch moment of inertia."
+        onChange={(v) => setMpParam('iyyOverrideKgM2', v as AircraftDesign['iyyOverrideKgM2'])}
+      />
+
+      <OverrideInput
+        label="MP07 — Izz (yaw)"
+        unit="kg·m²"
+        value={design.izzOverrideKgM2 ?? null}
+        min={0.0001}
+        max={10}
+        step={0.0001}
+        decimals={4}
+        placeholder="e.g. 0.0460"
+        title="Measured yaw moment of inertia."
+        onChange={(v) => setMpParam('izzOverrideKgM2', v as AircraftDesign['izzOverrideKgM2'])}
+      />
+
+      {/* Flight Condition */}
+      <SectionHeader>Flight Condition</SectionHeader>
+
+      <p className="text-[11px] text-zinc-500 mb-2">
+        Used by the DATCOM dynamic stability analysis.
+      </p>
+
+      <OverrideInput
+        label="FC01 — Cruise Speed"
+        unit="m/s"
+        value={design.flightSpeedMs ?? 50}
+        min={10}
+        max={100}
+        step={0.5}
+        decimals={1}
+        placeholder="50"
+        title="FC01: Cruise airspeed for dynamic stability analysis"
+        onChange={(v) => setMpParam('flightSpeedMs', (v ?? 50) as AircraftDesign['flightSpeedMs'])}
+      />
+
+      <OverrideInput
+        label="FC02 — Altitude"
+        unit="m MSL"
+        value={design.flightAltitudeM ?? 0}
+        min={0}
+        max={3000}
+        step={10}
+        decimals={0}
+        placeholder="0"
+        title="FC02: Flight altitude for ISA atmosphere model"
+        onChange={(v) => setMpParam('flightAltitudeM', (v ?? 0) as AircraftDesign['flightAltitudeM'])}
+      />
+    </section>
   );
 }

--- a/frontend/src/components/stability/MassPropertiesTab.tsx
+++ b/frontend/src/components/stability/MassPropertiesTab.tsx
@@ -1,0 +1,20 @@
+// ============================================================================
+// CHENG — Mass Properties Tab (stub)
+// Placeholder for the Mass Properties tab in the Stability Analysis overlay.
+// Full implementation will follow in a separate issue.
+// Issue #355
+// ============================================================================
+
+import React from 'react';
+
+/**
+ * Mass Properties Tab — stub placeholder.
+ * Full implementation in issue #357.
+ */
+export function MassPropertiesTab(): React.JSX.Element {
+  return (
+    <div className="p-4 text-xs text-zinc-400">
+      Mass Properties coming soon
+    </div>
+  );
+}

--- a/frontend/src/lib/dynamicStabilityAnalyzer.ts
+++ b/frontend/src/lib/dynamicStabilityAnalyzer.ts
@@ -32,7 +32,7 @@ export function classifyShortPeriod(zeta: number, omegaN: number): ModeQuality {
   if (zeta < 0.20 || zeta > 2.0) return 'poor';
 
   const zetaGood = zeta >= 0.35 && zeta <= 1.30;
-  const omegaGood = omegaN >= 1.0;
+  const omegaGood = omegaN > 1.0;  // strictly greater than — ωn = 1.0 rad/s is boundary (acceptable, not good)
 
   if (zetaGood && omegaGood) return 'good';
 

--- a/frontend/src/lib/dynamicStabilityAnalyzer.ts
+++ b/frontend/src/lib/dynamicStabilityAnalyzer.ts
@@ -75,8 +75,9 @@ export function classifyDutchRoll(zeta: number, omegaN: number): ModeQuality {
   if (zeta < 0) return 'poor';     // divergent
   if (zeta < 0.02) return 'poor';  // nearly neutral — unacceptable
 
-  if (zeta >= 0.08) return 'good';
-  return 'acceptable';  // 0.02 ≤ zeta < 0.08
+  // MIL-F-8785C also requires ωn >= 0.4 rad/s for Level 1 Dutch roll
+  if (zeta >= 0.08 && omegaN >= 0.4) return 'good';
+  return 'acceptable';  // 0.02 ≤ zeta < 0.08, or ωn too low
 }
 
 /**
@@ -108,7 +109,11 @@ export function classifyRollMode(tauS: number): ModeQuality {
  * @param t2S Time-to-double amplitude in seconds. Use Infinity for stable/convergent spiral.
  */
 export function classifySpiralMode(t2S: number): ModeQuality {
-  if (!isFinite(t2S)) return 'good';  // Infinity = stable
+  // NaN or undefined input is genuinely unknown (not good)
+  if (isNaN(t2S)) return 'unknown';
+
+  // +Infinity = stable spiral (never diverges) — best case
+  if (t2S === Infinity) return 'good';
 
   if (t2S < 0) return 'good';         // negative t2 = convergent spiral
   if (t2S >= 20) return 'good';

--- a/frontend/src/lib/dynamicStabilityAnalyzer.ts
+++ b/frontend/src/lib/dynamicStabilityAnalyzer.ts
@@ -1,0 +1,117 @@
+// ============================================================================
+// CHENG — Dynamic Stability Analyzer
+// Pure TypeScript utility for classifying dynamic mode quality.
+// Based on MIL-F-8785C and FAR 23 flying-quality requirements.
+// Issue #356
+// ============================================================================
+
+/**
+ * Quality classification for a dynamic stability mode.
+ * - 'good'       — meets Level 1 / desired flying qualities
+ * - 'acceptable' — meets Level 2 / adequate flying qualities
+ * - 'poor'       — fails Level 2 / unsatisfactory or dangerous
+ * - 'unknown'    — data unavailable or outside classification range
+ */
+export type ModeQuality = 'good' | 'acceptable' | 'poor' | 'unknown';
+
+/**
+ * Classify the short-period mode quality.
+ *
+ * Boundaries (based on MIL-F-8785C Category B):
+ * - Good:       0.35 ≤ ζ ≤ 1.30 and ωn > 1.0 rad/s
+ * - Acceptable: 0.20 ≤ ζ < 0.35, or 1.30 < ζ ≤ 2.0, or ωn ≤ 1.0 (if ζ in range)
+ * - Poor:       ζ < 0.20, or ζ > 2.0, or ωn ≤ 0
+ *
+ * @param zeta   Damping ratio (dimensionless).
+ * @param omegaN Natural frequency (rad/s).
+ */
+export function classifyShortPeriod(zeta: number, omegaN: number): ModeQuality {
+  if (!isFinite(zeta) || !isFinite(omegaN)) return 'unknown';
+  if (omegaN <= 0) return 'poor';
+
+  if (zeta < 0.20 || zeta > 2.0) return 'poor';
+
+  const zetaGood = zeta >= 0.35 && zeta <= 1.30;
+  const omegaGood = omegaN >= 1.0;
+
+  if (zetaGood && omegaGood) return 'good';
+
+  // Acceptable: damping is in 0.20–0.35 or 1.30–2.0 range, or omega marginal
+  return 'acceptable';
+}
+
+/**
+ * Classify the phugoid mode quality.
+ *
+ * Boundaries (FAR 23 / MIL-F-8785C):
+ * - Good:       ζ ≥ 0.04 (well-damped, pilot workload acceptable)
+ * - Acceptable: 0 < ζ < 0.04 (lightly damped but stable oscillation)
+ * - Poor:       ζ ≤ 0 (divergent or neutral)
+ *
+ * @param zeta Damping ratio (dimensionless).
+ */
+export function classifyPhugoid(zeta: number): ModeQuality {
+  if (!isFinite(zeta)) return 'unknown';
+
+  if (zeta >= 0.04) return 'good';
+  if (zeta > 0) return 'acceptable';
+  return 'poor';  // zeta <= 0: divergent
+}
+
+/**
+ * Classify the Dutch roll mode quality.
+ *
+ * Boundaries (MIL-F-8785C):
+ * - Good:       ζ ≥ 0.08 and ωn ≥ 0.4 rad/s
+ * - Acceptable: 0.02 ≤ ζ < 0.08 (lightly damped but stable)
+ * - Poor:       ζ < 0.02 or ζ < 0 (neutrally stable or divergent)
+ *
+ * @param zeta   Damping ratio (dimensionless).
+ * @param omegaN Natural frequency (rad/s).
+ */
+export function classifyDutchRoll(zeta: number, omegaN: number): ModeQuality {
+  if (!isFinite(zeta) || !isFinite(omegaN)) return 'unknown';
+
+  if (zeta < 0) return 'poor';     // divergent
+  if (zeta < 0.02) return 'poor';  // nearly neutral — unacceptable
+
+  if (zeta >= 0.08) return 'good';
+  return 'acceptable';  // 0.02 ≤ zeta < 0.08
+}
+
+/**
+ * Classify the roll mode quality.
+ *
+ * Based on MIL-F-8785C Category B (normal flight):
+ * - Good:       τ ≤ 0.5 s (fast roll response)
+ * - Acceptable: 0.5 < τ ≤ 1.0 s (sluggish but controllable)
+ * - Poor:       τ > 1.0 s (too sluggish for precision flying)
+ *
+ * @param tauS Time constant in seconds (must be > 0 for valid mode).
+ */
+export function classifyRollMode(tauS: number): ModeQuality {
+  if (!isFinite(tauS) || tauS <= 0) return 'unknown';
+
+  if (tauS <= 0.5) return 'good';
+  if (tauS <= 1.0) return 'acceptable';
+  return 'poor';
+}
+
+/**
+ * Classify the spiral mode quality.
+ *
+ * Spiral divergence (t2 = time-to-double) boundaries:
+ * - Good:       Stable (t2 = Infinity) or very slow divergence (t2 ≥ 20 s)
+ * - Acceptable: 8 s ≤ t2 < 20 s (pilot can correct in time)
+ * - Poor:       t2 < 8 s (too fast for pilot correction)
+ *
+ * @param t2S Time-to-double amplitude in seconds. Use Infinity for stable/convergent spiral.
+ */
+export function classifySpiralMode(t2S: number): ModeQuality {
+  if (!isFinite(t2S)) return 'good';  // Infinity = stable
+
+  if (t2S < 0) return 'good';         // negative t2 = convergent spiral
+  if (t2S >= 20) return 'good';
+  if (t2S >= 8) return 'acceptable';
+  return 'poor';
+}

--- a/tests/backend/test_airfoil_data.py
+++ b/tests/backend/test_airfoil_data.py
@@ -1,0 +1,230 @@
+"""Tests for backend/airfoil_data.py.
+
+Covers:
+- AIRFOIL_NAME_MAP completeness
+- load_airfoil_constants for all 12 airfoils
+- interpolate_section_aero return shape and value ranges
+- Boundary clamping behavior
+- get_available_airfoils()
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from backend.airfoil_data import (
+    AIRFOIL_NAME_MAP,
+    get_available_airfoils,
+    interpolate_section_aero,
+    load_airfoil_constants,
+)
+
+
+# ---------------------------------------------------------------------------
+# All 12 CHENG airfoil variants (hyphenated + space forms)
+# ---------------------------------------------------------------------------
+
+ALL_HYPHENATED = [
+    "Flat-Plate",
+    "NACA-0006",
+    "NACA-0009",
+    "NACA-0012",
+    "NACA-2412",
+    "NACA-4412",
+    "NACA-6412",
+    "Clark-Y",
+    "Eppler-193",
+    "Eppler-387",
+    "Selig-1223",
+    "AG-25",
+]
+
+ALL_SPACED = [
+    "Flat Plate",
+    "NACA 0006",
+    "NACA 0009",
+    "NACA 0012",
+    "NACA 2412",
+    "NACA 4412",
+    "NACA 6412",
+    "Clark Y",
+    "Eppler 193",
+    "Eppler 387",
+    "Selig 1223",
+    "AG 25",
+]
+
+_EXPECTED_KEYS = {"cl_alpha_per_rad", "cm_ac", "cl_max", "cd_min", "cl_at_cd_min"}
+
+# Standard test condition
+_RE = 300_000
+_MACH = 0.05
+
+
+# ---------------------------------------------------------------------------
+# AIRFOIL_NAME_MAP tests
+# ---------------------------------------------------------------------------
+
+
+class TestAirfoilNameMap:
+    """AIRFOIL_NAME_MAP completeness and correctness."""
+
+    def test_contains_all_hyphenated_forms(self) -> None:
+        """All 12 hyphenated forms must be in the name map."""
+        for name in ALL_HYPHENATED:
+            assert name in AIRFOIL_NAME_MAP, f"Missing hyphenated key: {name}"
+
+    def test_contains_all_spaced_forms(self) -> None:
+        """All 12 space-separated forms must be in the name map."""
+        for name in ALL_SPACED:
+            assert name in AIRFOIL_NAME_MAP, f"Missing spaced key: {name}"
+
+    def test_map_has_expected_length(self) -> None:
+        """Map should have exactly 24 entries (12 airfoils * 2 name forms)."""
+        assert len(AIRFOIL_NAME_MAP) == 24
+
+    def test_all_values_are_strings(self) -> None:
+        """All map values (JSON file stems) must be non-empty strings."""
+        for key, stem in AIRFOIL_NAME_MAP.items():
+            assert isinstance(stem, str) and stem, f"Stem for '{key}' is not a non-empty string"
+
+
+# ---------------------------------------------------------------------------
+# load_airfoil_constants tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAirfoilConstants:
+    """load_airfoil_constants loads JSON and returns expected structure."""
+
+    @pytest.mark.parametrize("name", ALL_HYPHENATED)
+    def test_loads_all_12_airfoils_without_error(self, name: str) -> None:
+        """Each of the 12 airfoils must load without exception."""
+        doc = load_airfoil_constants(name)
+        assert isinstance(doc, dict)
+
+    def test_returns_conditions_list(self) -> None:
+        """Loaded document must have a 'conditions' list with at least one entry."""
+        doc = load_airfoil_constants("NACA-2412")
+        assert "conditions" in doc
+        assert isinstance(doc["conditions"], list)
+        assert len(doc["conditions"]) > 0
+
+    def test_conditions_have_required_fields(self) -> None:
+        """Each condition entry must contain the 5 interpolated keys plus Re and Mach."""
+        doc = load_airfoil_constants("NACA-2412")
+        required = {"Re", "Mach", "cl_alpha_per_rad", "cm_ac", "cl_max", "cd_min", "cl_at_cd_min"}
+        for cond in doc["conditions"]:
+            for field in required:
+                assert field in cond, f"Missing field '{field}' in condition: {cond}"
+
+    def test_cache_returns_same_object(self) -> None:
+        """Calling load twice returns the same cached object."""
+        doc1 = load_airfoil_constants("Clark-Y")
+        doc2 = load_airfoil_constants("Clark-Y")
+        assert doc1 is doc2
+
+
+# ---------------------------------------------------------------------------
+# interpolate_section_aero tests
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolateSectionAero:
+    """interpolate_section_aero correctness, shape, and clamping."""
+
+    def test_returns_all_5_keys(self) -> None:
+        """Result must contain exactly the 5 expected keys."""
+        result = interpolate_section_aero("NACA 2412", Re=_RE, Mach=_MACH)
+        assert set(result.keys()) == _EXPECTED_KEYS
+
+    def test_all_values_are_finite(self) -> None:
+        """All returned values must be finite (no NaN, no inf)."""
+        result = interpolate_section_aero("NACA 2412", Re=_RE, Mach=_MACH)
+        for key, val in result.items():
+            assert math.isfinite(val), f"Non-finite value for {key}: {val}"
+
+    def test_cl_alpha_in_physical_range(self) -> None:
+        """CL_alpha should be between 3 and 8 per rad for a lifting airfoil at low Mach."""
+        result = interpolate_section_aero("NACA 2412", Re=_RE, Mach=_MACH)
+        assert 3.0 < result["cl_alpha_per_rad"] < 8.0, (
+            f"cl_alpha_per_rad = {result['cl_alpha_per_rad']} out of physical range"
+        )
+
+    def test_cl_max_positive(self) -> None:
+        """CL_max must be positive for a lifting airfoil."""
+        result = interpolate_section_aero("NACA 2412", Re=_RE, Mach=_MACH)
+        assert result["cl_max"] > 0.0
+
+    def test_cd_min_small_positive(self) -> None:
+        """CD_min must be a small positive number (skin friction drag)."""
+        result = interpolate_section_aero("NACA 2412", Re=_RE, Mach=_MACH)
+        assert 0.001 < result["cd_min"] < 0.05
+
+    def test_clamp_re_below_minimum_no_exception(self) -> None:
+        """Re below grid minimum must be clamped without exception."""
+        result = interpolate_section_aero("NACA 2412", Re=1.0, Mach=_MACH)
+        for key, val in result.items():
+            assert math.isfinite(val), f"Non-finite value for {key} at very low Re"
+
+    def test_clamp_mach_above_maximum_no_exception(self) -> None:
+        """Mach above grid maximum must be clamped without exception."""
+        result = interpolate_section_aero("NACA 2412", Re=_RE, Mach=100.0)
+        for key, val in result.items():
+            assert math.isfinite(val), f"Non-finite value for {key} at very high Mach"
+
+    def test_clamp_returns_boundary_not_nan(self) -> None:
+        """Clamping at boundaries should return boundary values, not NaN."""
+        result_low = interpolate_section_aero("Clark-Y", Re=1.0, Mach=0.001)
+        result_high = interpolate_section_aero("Clark-Y", Re=1e9, Mach=99.0)
+        for key in _EXPECTED_KEYS:
+            assert math.isfinite(result_low[key]), f"NaN at low boundary for {key}"
+            assert math.isfinite(result_high[key]), f"NaN at high boundary for {key}"
+
+    @pytest.mark.parametrize("name", ALL_HYPHENATED)
+    def test_all_12_airfoils_return_valid_values(self, name: str) -> None:
+        """All 12 airfoils must return valid (non-NaN) values at standard conditions."""
+        result = interpolate_section_aero(name, Re=_RE, Mach=_MACH)
+        assert set(result.keys()) == _EXPECTED_KEYS
+        for key, val in result.items():
+            assert math.isfinite(val), f"Non-finite {key} for airfoil {name}"
+
+    def test_hyphenated_and_spaced_names_match(self) -> None:
+        """Hyphenated and space-separated names for the same airfoil should produce identical results."""
+        r1 = interpolate_section_aero("NACA-4412", Re=_RE, Mach=_MACH)
+        r2 = interpolate_section_aero("NACA 4412", Re=_RE, Mach=_MACH)
+        for key in _EXPECTED_KEYS:
+            assert r1[key] == pytest.approx(r2[key], rel=1e-9), (
+                f"Mismatch for {key}: {r1[key]} vs {r2[key]}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# get_available_airfoils tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableAirfoils:
+    """get_available_airfoils() returns a usable list of stems."""
+
+    def test_returns_non_empty_list(self) -> None:
+        """get_available_airfoils() must return at least one entry."""
+        result = get_available_airfoils()
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_returns_12_airfoils(self) -> None:
+        """Exactly 12 airfoil stems should be available."""
+        result = get_available_airfoils()
+        assert len(result) == 12, f"Expected 12, got {len(result)}: {result}"
+
+    def test_stems_are_non_empty_strings(self) -> None:
+        """All returned stems must be non-empty strings."""
+        for stem in get_available_airfoils():
+            assert isinstance(stem, str) and stem
+
+    def test_naca2412_stem_present(self) -> None:
+        """The naca2412 stem must be in the available list."""
+        assert "naca2412" in get_available_airfoils()

--- a/tests/backend/test_datcom.py
+++ b/tests/backend/test_datcom.py
@@ -1,0 +1,347 @@
+"""Tests for backend/datcom.py.
+
+Covers:
+- compute_flight_condition(): ISA atmosphere, q_bar, CL_trim
+- compute_stability_derivatives(): sign conventions (Cm_q < 0, Cn_beta > 0, etc.)
+- compute_dynamic_modes(): all 6 presets, no NaN/inf in finite fields
+- Phugoid period vs Lanchester formula
+- Flying wing (BWB) completes without error
+- ISA atmosphere density vs altitude
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from backend.datcom import (
+    FlightCondition,
+    StabilityDerivatives,
+    DynamicModes,
+    compute_flight_condition,
+    compute_stability_derivatives,
+    compute_dynamic_modes,
+)
+from backend.mass_properties import resolve_mass_properties
+from backend.models import AircraftDesign
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _derived(design: AircraftDesign) -> dict:
+    from backend.geometry.engine import compute_derived_values
+    return compute_derived_values(design)
+
+
+def _mass_props(design: AircraftDesign, derived: dict):
+    return resolve_mass_properties(design, derived)
+
+
+def _trainer() -> AircraftDesign:
+    return AircraftDesign(
+        wing_span=1200,
+        wing_chord=200,
+        fuselage_length=400,
+        fuselage_preset="Conventional",
+        tail_arm=220,
+        h_stab_span=400,
+        h_stab_chord=120,
+        v_stab_height=120,
+        v_stab_root_chord=130,
+        motor_weight_g=120.0,
+        battery_weight_g=200.0,
+        flight_speed_ms=15.0,  # reasonable cruise speed for 1.2m trainer
+    )
+
+
+def _flying_wing() -> AircraftDesign:
+    return AircraftDesign(
+        wing_span=800,
+        wing_chord=250,
+        fuselage_length=300,
+        fuselage_preset="Blended-Wing-Body",
+        tail_arm=150,
+        motor_weight_g=100.0,
+        battery_weight_g=160.0,
+        flight_speed_ms=18.0,
+    )
+
+
+def _make_preset(preset: str) -> AircraftDesign:
+    presets = {
+        "Trainer": dict(wing_span=1200, wing_chord=200, fuselage_length=400,
+                        fuselage_preset="Conventional", tail_arm=220,
+                        h_stab_span=400, h_stab_chord=120,
+                        v_stab_height=120, v_stab_root_chord=130,
+                        motor_weight_g=120.0, battery_weight_g=200.0,
+                        flight_speed_ms=15.0),
+        "Sport": dict(wing_span=1000, wing_chord=180, fuselage_length=300,
+                      fuselage_preset="Conventional", tail_arm=180,
+                      h_stab_span=350, h_stab_chord=100,
+                      v_stab_height=100, v_stab_root_chord=110,
+                      motor_weight_g=100.0, battery_weight_g=180.0,
+                      flight_speed_ms=20.0),
+        "Aerobatic": dict(wing_span=900, wing_chord=200, fuselage_length=280,
+                          fuselage_preset="Conventional", tail_arm=160,
+                          h_stab_span=300, h_stab_chord=90,
+                          v_stab_height=90, v_stab_root_chord=100,
+                          motor_weight_g=90.0, battery_weight_g=150.0,
+                          flight_speed_ms=20.0),
+        "Glider": dict(wing_span=2000, wing_chord=150, fuselage_length=600,
+                       fuselage_preset="Conventional", tail_arm=350,
+                       h_stab_span=500, h_stab_chord=100,
+                       v_stab_height=120, v_stab_root_chord=120,
+                       motor_weight_g=80.0, battery_weight_g=100.0,
+                       flight_speed_ms=12.0),
+        "FlyingWing": dict(wing_span=800, wing_chord=250, fuselage_length=300,
+                           fuselage_preset="Blended-Wing-Body", tail_arm=150,
+                           motor_weight_g=100.0, battery_weight_g=160.0,
+                           flight_speed_ms=18.0),
+        "Scale": dict(wing_span=1500, wing_chord=220, fuselage_length=500,
+                      fuselage_preset="Conventional", tail_arm=280,
+                      h_stab_span=450, h_stab_chord=120,
+                      v_stab_height=130, v_stab_root_chord=130,
+                      motor_weight_g=150.0, battery_weight_g=250.0,
+                      flight_speed_ms=17.0),
+    }
+    return AircraftDesign(**presets[preset])
+
+
+# ---------------------------------------------------------------------------
+# compute_flight_condition tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFlightCondition:
+    """Flight condition: ISA atmosphere, dynamic pressure, trim CL."""
+
+    def setup_method(self) -> None:
+        self.design = _trainer()
+        self.derived = _derived(self.design)
+        self.mp = _mass_props(self.design, self.derived)
+        self.fc = compute_flight_condition(self.design, self.mp)
+
+    def test_returns_flight_condition(self) -> None:
+        assert isinstance(self.fc, FlightCondition)
+
+    def test_rho_positive(self) -> None:
+        """Air density must be positive."""
+        assert self.fc.rho > 0.0
+
+    def test_rho_sea_level_approx(self) -> None:
+        """Sea level density should be close to ISA standard (1.225 kg/m³)."""
+        assert 1.1 < self.fc.rho < 1.3, f"rho = {self.fc.rho} not near 1.225 kg/m³"
+
+    def test_q_bar_positive(self) -> None:
+        """Dynamic pressure must be positive."""
+        assert self.fc.q_bar > 0.0
+
+    def test_cl_trim_positive(self) -> None:
+        """CL_trim must be positive at level flight (weight = lift)."""
+        assert self.fc.CL_trim > 0.0
+
+    def test_speed_matches_design(self) -> None:
+        """Speed in flight condition must match design.flight_speed_ms."""
+        assert self.fc.speed_ms == pytest.approx(self.design.flight_speed_ms)
+
+    def test_isa_density_decreases_with_altitude(self) -> None:
+        """Air density should decrease as altitude increases (ISA lapse rate)."""
+        design_sl = _trainer()
+        design_sl.flight_altitude_m = 0.0
+        design_alt = _trainer()
+        design_alt.flight_altitude_m = 1000.0
+
+        derived_sl = _derived(design_sl)
+        derived_alt = _derived(design_alt)
+
+        mp_sl = _mass_props(design_sl, derived_sl)
+        mp_alt = _mass_props(design_alt, derived_alt)
+
+        fc_sl = compute_flight_condition(design_sl, mp_sl)
+        fc_alt = compute_flight_condition(design_alt, mp_alt)
+
+        assert fc_alt.rho < fc_sl.rho, (
+            f"Density at 1000m ({fc_alt.rho:.4f}) should be less than at 0m ({fc_sl.rho:.4f})"
+        )
+
+    def test_isa_sea_level_density_value(self) -> None:
+        """Sea level rho should be ~1.225 kg/m³ per ISA standard."""
+        design = _trainer()
+        design.flight_altitude_m = 0.0
+        derived = _derived(design)
+        mp = _mass_props(design, derived)
+        fc = compute_flight_condition(design, mp)
+        assert fc.rho == pytest.approx(1.225, abs=0.01), f"rho = {fc.rho}, expected ~1.225"
+
+
+# ---------------------------------------------------------------------------
+# compute_stability_derivatives tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStabilityDerivatives:
+    """Stability derivatives: sign conventions and physical ranges."""
+
+    def setup_method(self) -> None:
+        self.design = _trainer()
+        self.derived = _derived(self.design)
+        self.mp = _mass_props(self.design, self.derived)
+        self.fc = compute_flight_condition(self.design, self.mp)
+        self.derivs = compute_stability_derivatives(self.design, self.mp, self.fc)
+
+    def test_returns_stability_derivatives(self) -> None:
+        assert isinstance(self.derivs, StabilityDerivatives)
+
+    def test_cm_q_negative(self) -> None:
+        """Pitch damping Cm_q must be negative for a stable design."""
+        assert self.derivs.Cm_q < 0.0, f"Cm_q = {self.derivs.Cm_q} should be < 0"
+
+    def test_cn_beta_positive(self) -> None:
+        """Weathercock stability Cn_beta must be positive (restoring yaw moment)."""
+        assert self.derivs.Cn_beta > 0.0, f"Cn_beta = {self.derivs.Cn_beta} should be > 0"
+
+    def test_cl_p_negative(self) -> None:
+        """Roll damping Cl_p must be negative (opposes roll rate)."""
+        assert self.derivs.Cl_p < 0.0, f"Cl_p = {self.derivs.Cl_p} should be < 0"
+
+    def test_cl_alpha_in_physical_range(self) -> None:
+        """Aircraft lift curve slope CL_alpha should be between 3 and 7 /rad."""
+        assert 3.0 <= self.derivs.CL_alpha <= 7.0, (
+            f"CL_alpha = {self.derivs.CL_alpha} out of physical range [3, 7] /rad"
+        )
+
+    def test_cm_alpha_negative(self) -> None:
+        """Pitch stiffness Cm_alpha must be negative for pitch stability."""
+        assert self.derivs.Cm_alpha < 0.0, f"Cm_alpha = {self.derivs.Cm_alpha} should be < 0"
+
+    def test_cn_r_negative(self) -> None:
+        """Yaw damping Cn_r must be negative."""
+        assert self.derivs.Cn_r < 0.0, f"Cn_r = {self.derivs.Cn_r} should be < 0"
+
+
+# ---------------------------------------------------------------------------
+# compute_dynamic_modes tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDynamicModes:
+    """Dynamic modes: physical ranges for all 6 presets."""
+
+    def _run_modes(self, preset: str) -> DynamicModes:
+        design = _make_preset(preset)
+        derived = _derived(design)
+        mp = _mass_props(design, derived)
+        fc = compute_flight_condition(design, mp)
+        derivs = compute_stability_derivatives(design, mp, fc)
+        return compute_dynamic_modes(design, mp, fc, derivs)
+
+    @pytest.mark.parametrize("preset", ["Trainer", "Sport", "Aerobatic", "Glider", "FlyingWing", "Scale"])
+    def test_no_nan_in_mode_parameters(self, preset: str) -> None:
+        """No NaN values in the finite-expected mode parameters for all presets."""
+        modes = self._run_modes(preset)
+        finite_fields = [
+            "sp_omega_n", "sp_zeta", "sp_period_s",
+            "phugoid_omega_n", "phugoid_zeta", "phugoid_period_s",
+            "dr_omega_n", "dr_zeta", "dr_period_s",
+            "roll_tau_s", "spiral_tau_s",
+        ]
+        for field in finite_fields:
+            val = getattr(modes, field)
+            assert not math.isnan(val), f"Preset '{preset}': {field} = NaN"
+
+    @pytest.mark.parametrize("preset", ["Trainer", "Sport", "Aerobatic", "Glider", "FlyingWing", "Scale"])
+    def test_sp_omega_n_positive(self, preset: str) -> None:
+        """Short-period natural frequency must be positive."""
+        modes = self._run_modes(preset)
+        assert modes.sp_omega_n > 0.0, (
+            f"Preset '{preset}': sp_omega_n = {modes.sp_omega_n} should be > 0"
+        )
+
+    @pytest.mark.parametrize("preset", ["Trainer", "Sport", "Aerobatic", "Glider", "FlyingWing", "Scale"])
+    def test_sp_zeta_in_physical_range(self, preset: str) -> None:
+        """Short-period damping ratio should be in (0, 5) range."""
+        modes = self._run_modes(preset)
+        assert 0.0 < modes.sp_zeta < 5.0, (
+            f"Preset '{preset}': sp_zeta = {modes.sp_zeta} out of physical range (0, 5)"
+        )
+
+    def test_phugoid_period_vs_lanchester_trainer(self) -> None:
+        """Phugoid period should be within ±50% of Lanchester approximation for Trainer.
+
+        Lanchester (1908): T_ph = 2*pi*V / (g*sqrt(2))
+        """
+        design = _make_preset("Trainer")
+        derived = _derived(design)
+        mp = _mass_props(design, derived)
+        fc = compute_flight_condition(design, mp)
+        derivs = compute_stability_derivatives(design, mp, fc)
+        modes = compute_dynamic_modes(design, mp, fc, derivs)
+
+        V = fc.speed_ms
+        T_lanchester = 2.0 * math.pi * V / (9.80665 * math.sqrt(2.0))
+
+        assert modes.phugoid_period_s == pytest.approx(T_lanchester, rel=0.5), (
+            f"Phugoid period {modes.phugoid_period_s:.2f}s vs Lanchester {T_lanchester:.2f}s "
+            f"(tolerance ±50%)"
+        )
+
+    def test_spiral_t2s_trainer(self) -> None:
+        """Trainer spiral T2 should be math.inf or a large positive value."""
+        modes = self._run_modes("Trainer")
+        # Either inf (stable) or large positive (very slow divergence)
+        assert math.isinf(modes.spiral_t2_s) or modes.spiral_t2_s > 0.0, (
+            f"spiral_t2_s = {modes.spiral_t2_s} — must be inf or positive"
+        )
+
+    def test_flying_wing_no_error(self) -> None:
+        """Flying wing preset must complete without error."""
+        modes = self._run_modes("FlyingWing")
+        assert isinstance(modes, DynamicModes)
+
+    def test_returns_dynamic_modes_instance(self) -> None:
+        """compute_dynamic_modes() must return a DynamicModes instance."""
+        modes = self._run_modes("Trainer")
+        assert isinstance(modes, DynamicModes)
+
+    def test_roll_tau_s_positive(self) -> None:
+        """Roll mode time constant must be positive."""
+        modes = self._run_modes("Trainer")
+        assert modes.roll_tau_s > 0.0, f"roll_tau_s = {modes.roll_tau_s} should be > 0"
+
+    def test_derivative_passthrough_cl_alpha(self) -> None:
+        """DynamicModes should have CL_alpha passthrough field populated."""
+        modes = self._run_modes("Trainer")
+        assert modes.CL_alpha > 0.0, (
+            f"CL_alpha passthrough = {modes.CL_alpha} should be > 0"
+        )
+
+    def test_derivative_passthrough_cn_beta(self) -> None:
+        """DynamicModes should have Cn_beta passthrough field populated."""
+        modes = self._run_modes("Trainer")
+        assert modes.Cn_beta > 0.0, (
+            f"Cn_beta passthrough = {modes.Cn_beta} should be > 0"
+        )
+
+    def test_derivatives_estimated_flag(self) -> None:
+        """derivatives_estimated field should be True by default."""
+        modes = self._run_modes("Trainer")
+        assert modes.derivatives_estimated is True
+
+    @pytest.mark.parametrize("preset", ["Trainer", "Sport", "Aerobatic", "Glider", "Scale"])
+    def test_no_inf_in_non_spiral_fields(self, preset: str) -> None:
+        """All mode fields except spiral_t2_s should be finite for conventional configs."""
+        modes = self._run_modes(preset)
+        inf_disallowed = [
+            "sp_omega_n", "sp_zeta", "sp_period_s",
+            "phugoid_omega_n", "phugoid_zeta", "phugoid_period_s",
+            "dr_omega_n", "dr_zeta", "dr_period_s",
+            "roll_tau_s", "spiral_tau_s",
+        ]
+        for field in inf_disallowed:
+            val = getattr(modes, field)
+            assert math.isfinite(val), (
+                f"Preset '{preset}': {field} = {val} — expected finite"
+            )

--- a/tests/backend/test_derived_values.py
+++ b/tests/backend/test_derived_values.py
@@ -253,7 +253,7 @@ class TestDerivedEdgeCases:
         assert d["wall_thickness_mm"] == pytest.approx(1.5)
 
     def test_all_derived_keys_present(self):
-        """All 19 derived keys should be in the result (12 base + 7 stability v1.1)."""
+        """All 20 derived keys should be in the result (12 base + 7 stability v1.1 + 1 dynamic v1.2)."""
         d = compute_derived_values(_trainer())
         expected_keys = {
             # Base derived values (12)
@@ -277,5 +277,7 @@ class TestDerivedEdgeCases:
             "tail_volume_h",
             "tail_volume_v",
             "wing_loading_g_dm2",
+            # Dynamic stability field (v1.2, 1 field — nested DynamicStabilityResult or None)
+            "dynamic_stability",
         }
         assert set(d.keys()) == expected_keys

--- a/tests/backend/test_mass_properties.py
+++ b/tests/backend/test_mass_properties.py
@@ -1,0 +1,285 @@
+"""Tests for backend/mass_properties.py.
+
+Covers:
+- resolve_mass_properties() with all overrides set
+- resolve_mass_properties() with no overrides (estimates)
+- ixx_estimated / iyy_estimated / izz_estimated flags
+- estimate_inertia() physical ordering (Ixx < Iyy) for all 6 presets
+- Partial overrides
+- SI unit correctness
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.models import AircraftDesign
+from backend.mass_properties import MassProperties, estimate_inertia, resolve_mass_properties
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _trainer() -> AircraftDesign:
+    """Trainer-like design (1200 mm span, conventional)."""
+    return AircraftDesign(
+        wing_span=1200,
+        wing_chord=200,
+        fuselage_length=400,
+        fuselage_preset="Conventional",
+        tail_arm=220,
+        motor_weight_g=120.0,
+        battery_weight_g=200.0,
+    )
+
+
+def _derived(design: AircraftDesign | None = None) -> dict:
+    """Compute derived values dict for a design."""
+    from backend.geometry.engine import compute_derived_values
+    if design is None:
+        design = _trainer()
+    return compute_derived_values(design)
+
+
+def _make_design(preset: str) -> AircraftDesign:
+    """Create a minimal design for each preset name."""
+    if preset == "Trainer":
+        return AircraftDesign(
+            wing_span=1200, wing_chord=200, fuselage_length=400,
+            fuselage_preset="Conventional", tail_arm=220,
+            motor_weight_g=120.0, battery_weight_g=200.0,
+        )
+    elif preset == "Sport":
+        return AircraftDesign(
+            wing_span=1000, wing_chord=180, fuselage_length=300,
+            fuselage_preset="Conventional", tail_arm=180,
+            motor_weight_g=100.0, battery_weight_g=180.0,
+        )
+    elif preset == "Aerobatic":
+        return AircraftDesign(
+            wing_span=900, wing_chord=200, fuselage_length=280,
+            fuselage_preset="Conventional", tail_arm=160,
+            motor_weight_g=90.0, battery_weight_g=150.0,
+        )
+    elif preset == "Glider":
+        return AircraftDesign(
+            wing_span=2000, wing_chord=150, fuselage_length=600,
+            fuselage_preset="Conventional", tail_arm=350,
+            motor_weight_g=80.0, battery_weight_g=100.0,
+        )
+    elif preset == "FlyingWing":
+        return AircraftDesign(
+            wing_span=800, wing_chord=250, fuselage_length=300,
+            fuselage_preset="Blended-Wing-Body", tail_arm=150,
+            motor_weight_g=100.0, battery_weight_g=160.0,
+        )
+    elif preset == "Scale":
+        return AircraftDesign(
+            wing_span=1500, wing_chord=220, fuselage_length=500,
+            fuselage_preset="Conventional", tail_arm=280,
+            motor_weight_g=150.0, battery_weight_g=250.0,
+        )
+    else:
+        raise ValueError(f"Unknown preset: {preset}")
+
+
+# ---------------------------------------------------------------------------
+# resolve_mass_properties — with all overrides set
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMassPropertiesWithOverrides:
+    """All MP01-MP07 overrides active — resolver returns exact override values."""
+
+    def setup_method(self) -> None:
+        self.design = _trainer()
+        self.design.mass_total_override_g = 850.0
+        self.design.cg_override_x_mm = 120.0
+        self.design.cg_override_z_mm = 5.0
+        self.design.cg_override_y_mm = -2.0
+        self.design.ixx_override_kg_m2 = 0.012
+        self.design.iyy_override_kg_m2 = 0.045
+        self.design.izz_override_kg_m2 = 0.055
+        self.derived = _derived(self.design)
+        self.mp = resolve_mass_properties(self.design, self.derived)
+
+    def test_mass_uses_override(self) -> None:
+        assert self.mp.mass_g == pytest.approx(850.0)
+
+    def test_cg_x_uses_override(self) -> None:
+        assert self.mp.cg_x_mm == pytest.approx(120.0)
+
+    def test_cg_z_uses_override(self) -> None:
+        assert self.mp.cg_z_mm == pytest.approx(5.0)
+
+    def test_cg_y_uses_override(self) -> None:
+        assert self.mp.cg_y_mm == pytest.approx(-2.0)
+
+    def test_ixx_uses_override(self) -> None:
+        assert self.mp.ixx_kg_m2 == pytest.approx(0.012)
+
+    def test_iyy_uses_override(self) -> None:
+        assert self.mp.iyy_kg_m2 == pytest.approx(0.045)
+
+    def test_izz_uses_override(self) -> None:
+        assert self.mp.izz_kg_m2 == pytest.approx(0.055)
+
+    def test_ixx_estimated_false(self) -> None:
+        assert self.mp.ixx_estimated is False
+
+    def test_iyy_estimated_false(self) -> None:
+        assert self.mp.iyy_estimated is False
+
+    def test_izz_estimated_false(self) -> None:
+        assert self.mp.izz_estimated is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_mass_properties — with no overrides (all estimated)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMassPropertiesNoOverrides:
+    """No overrides — resolver returns estimated values."""
+
+    def setup_method(self) -> None:
+        self.design = _trainer()
+        self.derived = _derived(self.design)
+        self.mp = resolve_mass_properties(self.design, self.derived)
+
+    def test_returns_mass_properties_instance(self) -> None:
+        assert isinstance(self.mp, MassProperties)
+
+    def test_mass_g_positive(self) -> None:
+        """Total mass must be positive (airframe + motor + battery)."""
+        assert self.mp.mass_g > 0.0
+
+    def test_mass_includes_motor_and_battery(self) -> None:
+        """Estimated mass must be at least motor + battery weight."""
+        min_mass = self.design.motor_weight_g + self.design.battery_weight_g
+        assert self.mp.mass_g >= min_mass
+
+    def test_cg_x_mm_positive(self) -> None:
+        """Nose-referenced CG must be positive (forward of nose = impossible)."""
+        assert self.mp.cg_x_mm > 0.0
+
+    def test_ixx_estimated_true(self) -> None:
+        assert self.mp.ixx_estimated is True
+
+    def test_iyy_estimated_true(self) -> None:
+        assert self.mp.iyy_estimated is True
+
+    def test_izz_estimated_true(self) -> None:
+        assert self.mp.izz_estimated is True
+
+    def test_ixx_is_si_units_range(self) -> None:
+        """Ixx for a ~1.2m wingspan model should be in 0.001 – 1.0 kg·m² range."""
+        assert 0.001 <= self.mp.ixx_kg_m2 <= 1.0, (
+            f"Ixx = {self.mp.ixx_kg_m2} kg·m² out of expected range for model aircraft"
+        )
+
+    def test_iyy_is_si_units_range(self) -> None:
+        """Iyy for a ~400mm fuselage model should be in 0.001 – 5.0 kg·m² range."""
+        assert 0.001 <= self.mp.iyy_kg_m2 <= 5.0, (
+            f"Iyy = {self.mp.iyy_kg_m2} kg·m² out of expected range"
+        )
+
+
+# ---------------------------------------------------------------------------
+# estimate_inertia — physical ordering for all 6 presets
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateInertiaPhysicalOrdering:
+    """estimate_inertia() must satisfy Ixx < Iyy for all presets.
+
+    RC models have wide wingspans relative to fuselage length, so the
+    dominant inertia axis is pitch (Iyy) not roll (Ixx).
+    """
+
+    @pytest.mark.parametrize("preset", ["Trainer", "Sport", "Aerobatic", "Glider", "FlyingWing", "Scale"])
+    def test_ixx_less_than_iyy(self, preset: str) -> None:
+        """Ixx < Iyy for all presets."""
+        design = _make_design(preset)
+        from backend.geometry.engine import compute_derived_values
+        derived = compute_derived_values(design)
+        ixx, iyy, izz = estimate_inertia(design, derived)
+        assert ixx < iyy, (
+            f"Preset '{preset}': Ixx={ixx:.6f} >= Iyy={iyy:.6f} kg·m² — physical ordering violated"
+        )
+
+    @pytest.mark.parametrize("preset", ["Trainer", "Sport", "Aerobatic", "Glider", "FlyingWing", "Scale"])
+    def test_all_inertia_positive(self, preset: str) -> None:
+        """All three inertia values must be strictly positive."""
+        design = _make_design(preset)
+        from backend.geometry.engine import compute_derived_values
+        derived = compute_derived_values(design)
+        ixx, iyy, izz = estimate_inertia(design, derived)
+        assert ixx > 0.0, f"Preset '{preset}': Ixx <= 0"
+        assert iyy > 0.0, f"Preset '{preset}': Iyy <= 0"
+        assert izz > 0.0, f"Preset '{preset}': Izz <= 0"
+
+
+# ---------------------------------------------------------------------------
+# Partial overrides
+# ---------------------------------------------------------------------------
+
+
+class TestPartialOverrides:
+    """Partial override: only mass set, inertia is still estimated."""
+
+    def setup_method(self) -> None:
+        self.design = _trainer()
+        self.design.mass_total_override_g = 750.0
+        # No inertia overrides
+        self.derived = _derived(self.design)
+        self.mp = resolve_mass_properties(self.design, self.derived)
+
+    def test_mass_uses_override(self) -> None:
+        assert self.mp.mass_g == pytest.approx(750.0)
+
+    def test_ixx_estimated_true(self) -> None:
+        """Without MP05, Ixx must still be estimated."""
+        assert self.mp.ixx_estimated is True
+
+    def test_iyy_estimated_true(self) -> None:
+        """Without MP06, Iyy must still be estimated."""
+        assert self.mp.iyy_estimated is True
+
+    def test_izz_estimated_true(self) -> None:
+        """Without MP07, Izz must still be estimated."""
+        assert self.mp.izz_estimated is True
+
+    def test_cg_x_is_nose_referenced(self) -> None:
+        """Without MP02 override, CG fallback is 30% of fuselage_length from nose."""
+        expected = self.design.fuselage_length * 0.30
+        assert self.mp.cg_x_mm == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# SI unit correctness
+# ---------------------------------------------------------------------------
+
+
+class TestSIUnits:
+    """Inertia values must be in kg·m², not gram-based or mm-based units."""
+
+    def test_inertia_not_in_grams(self) -> None:
+        """If inertia were in g·mm², values would be millions — check they are not."""
+        design = _trainer()
+        derived = _derived(design)
+        ixx, iyy, izz = estimate_inertia(design, derived)
+        # kg·m² for a 1kg model: ~0.001 – 1.0; g·mm² would be ~1e6 times larger
+        assert ixx < 100.0, f"Ixx={ixx} suspiciously large — check units"
+        assert iyy < 100.0, f"Iyy={iyy} suspiciously large — check units"
+        assert izz < 100.0, f"Izz={izz} suspiciously large — check units"
+
+    def test_inertia_not_too_small(self) -> None:
+        """Inertia in SI must be > 1e-6 for any reasonable RC model."""
+        design = _trainer()
+        derived = _derived(design)
+        ixx, iyy, izz = estimate_inertia(design, derived)
+        assert ixx > 1e-6, f"Ixx={ixx} suspiciously small"
+        assert iyy > 1e-6, f"Iyy={iyy} suspiciously small"
+        assert izz > 1e-6, f"Izz={izz} suspiciously small"

--- a/tests/frontend/e2e/dynamic-stability.spec.ts
+++ b/tests/frontend/e2e/dynamic-stability.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * CHENG E2E Tests — Dynamic Stability Feature
+ *
+ * Tests for the DATCOM dynamic stability overlay tabs, mass properties
+ * overrides, in-viewport summary card, and quality badge display.
+ *
+ * Requires the full app (backend + frontend) running:
+ *   powershell -ExecutionPolicy Bypass -File .\bootup.ps1
+ *
+ * Backend must have DATCOM pipeline integrated (issues #349-#353).
+ *
+ * Run: cd frontend && NODE_PATH=./node_modules npx playwright test e2e/dynamic-stability.spec.ts
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Wait for the app to be fully loaded and WebSocket connected. */
+async function waitForAppReady(page: Page): Promise<void> {
+  await page.waitForSelector('main', { timeout: 15_000 });
+  await page.waitForSelector('canvas', { timeout: 15_000 });
+  const firstInput = page.locator('input[type="number"]').first();
+  await expect(firstInput).toBeVisible({ timeout: 10_000 });
+  // Extra wait for first WebSocket message (derived values) to arrive
+  await page.waitForTimeout(2_000);
+}
+
+/** Open the stability overlay by clicking "Toggle Plots" in the toolbar. */
+async function openStabilityOverlay(page: Page): Promise<void> {
+  const toggleButton = page.getByRole('button', { name: /show stability plots/i });
+  await expect(toggleButton).toBeVisible({ timeout: 5_000 });
+  await toggleButton.click();
+  await expect(page.getByRole('dialog', { name: /stability analysis/i })).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+/** Switch to a tab inside the stability overlay. */
+async function switchStabilityTab(page: Page, tabName: string): Promise<void> {
+  const tab = page.getByRole('tab', { name: new RegExp(tabName, 'i') });
+  await expect(tab).toBeVisible({ timeout: 3_000 });
+  await tab.click();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Dynamic Stability Overlay', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+  });
+
+  test('1 — tab navigation: overlay has 3 tabs and switching changes content', async ({ page }) => {
+    await openStabilityOverlay(page);
+
+    const overlay = page.getByRole('dialog', { name: /stability analysis/i });
+    await expect(overlay).toBeVisible();
+
+    // All 3 tabs should be present
+    await expect(page.getByRole('tab', { name: /static/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /mass/i })).toBeVisible();
+    await expect(page.getByRole('tab', { name: /dynamic/i })).toBeVisible();
+
+    // Static tab: should show CG/NP gauge content
+    await switchStabilityTab(page, 'static');
+    const staticContent = page.getByRole('tabpanel');
+    await expect(staticContent).toBeVisible();
+
+    // Mass tab: should show different content
+    await switchStabilityTab(page, 'mass');
+    const massContent = page.getByRole('tabpanel');
+    await expect(massContent).toBeVisible();
+
+    // Dynamic tab: should show different content
+    await switchStabilityTab(page, 'dynamic');
+    const dynamicContent = page.getByRole('tabpanel');
+    await expect(dynamicContent).toBeVisible();
+  });
+
+  test('2 — mode cards visible: Dynamic Stability tab shows 5 mode sections', async ({ page }) => {
+    await openStabilityOverlay(page);
+    await switchStabilityTab(page, 'dynamic');
+
+    const tabPanel = page.getByRole('tabpanel');
+    await expect(tabPanel).toBeVisible();
+
+    // All 5 dynamic modes should appear in the panel
+    await expect(tabPanel.getByText(/short.period/i)).toBeVisible({ timeout: 8_000 });
+    await expect(tabPanel.getByText(/phugoid/i)).toBeVisible({ timeout: 5_000 });
+    await expect(tabPanel.getByText(/dutch roll/i)).toBeVisible({ timeout: 5_000 });
+    await expect(tabPanel.getByText(/roll mode/i)).toBeVisible({ timeout: 5_000 });
+    await expect(tabPanel.getByText(/spiral/i)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('3 — quality badges: at least one quality badge is visible in dynamic tab', async ({ page }) => {
+    await openStabilityOverlay(page);
+    await switchStabilityTab(page, 'dynamic');
+
+    const tabPanel = page.getByRole('tabpanel');
+
+    // Quality badges should be rendered (Good, Acceptable, or Poor)
+    // We check for at least one badge text — the exact badge depends on the design
+    const badges = tabPanel.locator('[aria-label^="Quality:"]');
+    await expect(badges.first()).toBeVisible({ timeout: 8_000 });
+
+    // The badge should have one of the expected quality texts
+    const badgeText = await badges.first().textContent();
+    expect(['Good', 'Acceptable', 'Poor', 'Unknown']).toContain(badgeText?.trim());
+  });
+
+  test('4 — flight speed input: changing speed in Mass Properties tab is reflected', async ({ page }) => {
+    await openStabilityOverlay(page);
+    await switchStabilityTab(page, 'mass');
+
+    // The Mass Properties tab should contain flight condition parameters
+    const tabPanel = page.getByRole('tabpanel');
+    await expect(tabPanel).toBeVisible();
+
+    // Look for the flight speed input (FC01)
+    // This verifies the tab renders interactive controls
+    const speedInputs = tabPanel.locator('input[type="number"]');
+    const count = await speedInputs.count();
+    // There should be at least one numeric input in the mass properties tab
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test('5 — mass properties tab: override toggle buttons are present', async ({ page }) => {
+    await openStabilityOverlay(page);
+    await switchStabilityTab(page, 'mass');
+
+    const tabPanel = page.getByRole('tabpanel');
+    await expect(tabPanel).toBeVisible({ timeout: 5_000 });
+
+    // Should show "Resolved Values" section or numeric inputs for mass/CG
+    // The tab renders MP01-MP07 optional override inputs
+    await expect(tabPanel.getByText(/mass/i).first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('6 — mass override round-trip: entering mass override value persists in input', async ({ page }) => {
+    await openStabilityOverlay(page);
+    await switchStabilityTab(page, 'mass');
+
+    const tabPanel = page.getByRole('tabpanel');
+
+    // Find the first numeric input in the tab (should be mass override or similar)
+    const inputs = tabPanel.locator('input[type="number"]');
+    const count = await inputs.count();
+
+    if (count > 0) {
+      const firstInput = inputs.first();
+      await expect(firstInput).toBeVisible({ timeout: 5_000 });
+
+      // Get current value and check it's readable
+      const currentValue = await firstInput.inputValue();
+      expect(currentValue).not.toBeNull();
+
+      // Type a new value and verify it's persisted
+      await firstInput.fill('500');
+      await page.keyboard.press('Tab');
+
+      // Verify the input now shows 500 (or is validated to a nearby valid value)
+      const newValue = await firstInput.inputValue();
+      expect(newValue).not.toBe('');
+    } else {
+      // If no inputs (e.g., tab shows only read-only estimated values with no overrides set),
+      // just verify the tab panel is rendered correctly
+      await expect(tabPanel.getByText(/estimated/i)).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test('7 — summary card: visible in viewport and opens overlay to dynamic tab on click', async ({ page }) => {
+    // Close overlay if open (summary card is hidden when overlay is open)
+    const overlay = page.getByRole('dialog', { name: /stability analysis/i });
+    const isOverlayVisible = await overlay.isVisible();
+    if (isOverlayVisible) {
+      await page.getByRole('button', { name: /close stability analysis/i }).click();
+    }
+
+    // Wait for DATCOM results to arrive (summary card only appears when dynamicStability is non-null)
+    const summaryCard = page.getByRole('button', { name: /dynamic stability summary/i });
+    await expect(summaryCard).toBeVisible({ timeout: 12_000 });
+
+    // Verify it's at the bottom-left (has fixed positioning class)
+    const cardClasses = await summaryCard.getAttribute('class');
+    expect(cardClasses).toContain('fixed');
+    expect(cardClasses).toContain('bottom-4');
+    expect(cardClasses).toContain('left-4');
+
+    // Click the card — should open overlay
+    await summaryCard.click();
+
+    // Overlay should now be open
+    await expect(overlay).toBeVisible({ timeout: 5_000 });
+
+    // Active tab should be "Dynamic Stability"
+    const dynamicTab = page.getByRole('tab', { name: /dynamic/i });
+    await expect(dynamicTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('8 — ESTIMATED badge: Dynamic Stability tab shows ESTIMATED badge for computed derivatives', async ({ page }) => {
+    await openStabilityOverlay(page);
+    await switchStabilityTab(page, 'dynamic');
+
+    const tabPanel = page.getByRole('tabpanel');
+    await expect(tabPanel).toBeVisible();
+
+    // The DynamicStabilityTab renders an "ESTIMATED" badge when derivatives_estimated is true
+    // (which is always true for our DATCOM estimates — no test-stand measurements)
+    // Wait for content to load from WebSocket
+    const estimatedBadge = tabPanel.getByText(/estimated/i);
+    await expect(estimatedBadge.first()).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary
- Merges `plan/dynamic-stability-datcom` into `main`
- Feature A: Mass Properties Override (MP01-MP07) — 7 optional fields with geometric inertia fallback
- Feature B: DATCOM Dynamic Stability Analysis — 16 stability derivatives + 5 dynamic modes (short-period, phugoid, Dutch roll, roll, spiral) using pre-computed NeuralFoil airfoil constants
- 13 new validation warnings (V36-V48)
- 3-tab StabilityOverlay (Static / Mass Properties / Dynamic Stability)
- In-viewport DynamicStabilitySummaryCard component
- 128 new backend tests (932 total), 8 new Playwright E2E tests

## Issues closed
#349 #350 #351 #352 #353 #354 #355 #356 #357 #358 #359 #360 #361

## Test results
- Backend pytest: 932 passed, 1 pre-existing failure (unrelated)
- Frontend Vitest: 339 passed, 3 pre-existing failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)